### PR TITLE
register observations to the device after sign in success

### DIFF
--- a/bundle/run.sh
+++ b/bundle/run.sh
@@ -54,7 +54,7 @@ if [ "$INITIALIZE_CERITIFICATES" = "true" ]; then
   mkdir -p $CA_POOL_DIR
   mkdir -p $INTERNAL_CERT_DIR_PATH
   mkdir -p $EXTERNAL_CERT_DIR_PATH
-  fqdnSAN="--cert.san.cn=$FQDN"
+  fqdnSAN="--cert.san.domain=$FQDN"
   if ip route get $FQDN 2>/dev/null >/dev/null; then
     fqdnSAN="--cert.san.ip=$FQDN"
   fi


### PR DESCRIPTION
cloud need to know which resources still avalaible from the device.
So after signIn cloud try to observe/get all resources, which
are published at the cloud, from the device. and the device returns
notfound resource is unpublished from the cloud.