### PR TITLE
coap-gateway/resourceDiscovery: fix time to live checks

### DIFF
--- a/coap-gateway/service/resourceDirectory.go
+++ b/coap-gateway/service/resourceDirectory.go
@@ -23,9 +23,16 @@ type wkRd struct {
 	TimeToLiveLegacy int                  `json:"lt"`
 }
 
+func makeWkRd() wkRd {
+	return wkRd{
+		TimeToLive:       -1,
+		TimeToLiveLegacy: -1,
+	}
+}
+
 func fixTTL(w wkRd) wkRd {
 	// set time to live properly
-	if w.TimeToLive <= 0 {
+	if w.TimeToLive < 0 {
 		w.TimeToLive = w.TimeToLiveLegacy
 	} else {
 		w.TimeToLiveLegacy = w.TimeToLive
@@ -51,7 +58,7 @@ func validatePublish(w wkRd) error {
 	if len(w.Links) == 0 {
 		return errors.New("empty links")
 	}
-	if w.TimeToLive <= 0 && w.TimeToLiveLegacy <= 0 {
+	if w.TimeToLive < 0 && w.TimeToLiveLegacy < 0 {
 		return errors.New("invalid TimeToLive")
 	}
 
@@ -65,7 +72,7 @@ func resourceDirectoryPublishHandler(req *mux.Message, client *Client) {
 		return
 	}
 
-	var w wkRd
+	w := makeWkRd()
 	err = cbor.ReadFrom(req.Body, &w)
 	if err != nil {
 		client.logAndWriteErrorResponse(fmt.Errorf("cannot read publish request body received from device %v: %w", authCtx.GetDeviceID(), err), coapCodes.BadRequest, req.Token)

--- a/coap-gateway/service/resourceDirectory_test.go
+++ b/coap-gateway/service/resourceDirectory_test.go
@@ -37,8 +37,10 @@ var tblResourceDirectory = []testEl{
 	{"BadRequest2", input{coapCodes.POST, `{ "di":"` + CertIdentity + `", "links":[ "abc" ]}`, nil}, output{coapCodes.BadRequest, `cbor: cannot unmarshal`, nil}},
 	{"BadRequest3", input{coapCodes.POST, `{ "di":"` + CertIdentity + `", "links":[ {} ]}`, nil}, output{coapCodes.BadRequest, `invalid TimeToLive`, nil}},
 	{"BadRequest4", input{coapCodes.POST, `{ "di":"` + CertIdentity + `", "links":[ { "href":"" } ]}`, nil}, output{coapCodes.BadRequest, `invalid TimeToLive`, nil}},
-	{"BadRequest5", input{coapCodes.POST, `{ "di":"` + CertIdentity + `", "links":[ { "di":"` + CertIdentity + `", "href":"" } ], "ttl":12345}`, nil}, output{coapCodes.BadRequest, `invalid resource href`, nil}},
-	{"BadRequest6", input{coapCodes.POST, `{ "di":"` + CertIdentity + `", "links":[ { "href":"" } ], "ttl":12345}`, nil}, output{coapCodes.BadRequest, `invalid resource href`, nil}},
+	{"BadRequest5", input{coapCodes.POST, `{ "di":"` + CertIdentity + `", "links":[ {} ], "ttl":-1}`, nil}, output{coapCodes.BadRequest, `invalid TimeToLive`, nil}},
+	{"BadRequest6", input{coapCodes.POST, `{ "di":"` + CertIdentity + `", "links":[ {} ], "lt":-1}`, nil}, output{coapCodes.BadRequest, `invalid TimeToLive`, nil}},
+	{"BadRequest7", input{coapCodes.POST, `{ "di":"` + CertIdentity + `", "links":[ { "di":"` + CertIdentity + `", "href":"" } ], "ttl":12345}`, nil}, output{coapCodes.BadRequest, `invalid resource href`, nil}},
+	{"BadRequest8", input{coapCodes.POST, `{ "di":"` + CertIdentity + `", "links":[ { "href":"" } ], "ttl":12345}`, nil}, output{coapCodes.BadRequest, `invalid resource href`, nil}},
 	{"Changed0", input{coapCodes.POST, `{ "di":"` + CertIdentity + `", "links":[ { "di":"` + CertIdentity + `", "href":"` + TestAResourceHref + `" } ], "ttl":12345}`, nil},
 		output{coapCodes.Changed, TestWkRD{
 			DeviceID:         CertIdentity,
@@ -77,6 +79,30 @@ var tblResourceDirectory = []testEl{
 				{
 					DeviceID: CertIdentity,
 					Href:     "/c",
+				},
+			},
+		}, nil}},
+	{"Changed3", input{coapCodes.POST, `{ "di":"` + CertIdentity + `", "links":[ { "di":"` + CertIdentity + `", "href":"` + TestAResourceHref + `" } ], "ttl":0}`, nil},
+		output{coapCodes.Changed, TestWkRD{
+			DeviceID:         CertIdentity,
+			TimeToLive:       0,
+			TimeToLiveLegacy: 0,
+			Links: []TestResource{
+				{
+					DeviceID: CertIdentity,
+					Href:     TestAResourceHref,
+				},
+			},
+		}, nil}},
+	{"Changed4", input{coapCodes.POST, `{ "di":"` + CertIdentity + `", "links":[ { "di":"` + CertIdentity + `", "href":"` + TestAResourceHref + `" } ], "lt":0}`, nil},
+		output{coapCodes.Changed, TestWkRD{
+			DeviceID:         CertIdentity,
+			TimeToLive:       0,
+			TimeToLiveLegacy: 0,
+			Links: []TestResource{
+				{
+					DeviceID: CertIdentity,
+					Href:     TestAResourceHref,
 				},
 			},
 		}, nil}},

--- a/coap-gateway/service/resourceDiscovery.go
+++ b/coap-gateway/service/resourceDiscovery.go
@@ -68,8 +68,10 @@ func makeDiscoveryResp(isTLSListener bool, serverAddr string, getResourceLinksCl
 		d, ok := deviceRes[snapshot.GetDeviceId()]
 		if !ok {
 			d = &wkRd{
-				DeviceID: snapshot.GetDeviceId(),
-				Links:    make(schema.ResourceLinks, 0, 16),
+				DeviceID:         snapshot.GetDeviceId(),
+				Links:            make(schema.ResourceLinks, 0, 16),
+				TimeToLive:       -1,
+				TimeToLiveLegacy: -1,
 			}
 			deviceRes[snapshot.GetDeviceId()] = d
 		}


### PR DESCRIPTION
Use value of -1 instead of 0 to signal that TimeToLive or
TimeToLiveLegacy are not set. Value of 0 is used by
iotivity-lite to signal that TimeToLive is unlimited.