### PR TITLE
resource-aggregate: skip duplicate deviceMetadataUpdated events

### DIFF
--- a/resource-aggregate/events/deviceMetadataUpdated.go
+++ b/resource-aggregate/events/deviceMetadataUpdated.go
@@ -34,3 +34,12 @@ func (e *DeviceMetadataUpdated) GroupID() string {
 func (e *DeviceMetadataUpdated) IsSnapshot() bool {
 	return false
 }
+
+// Check if two DeviceMetadataUpdated events are equal
+func (e *DeviceMetadataUpdated) Equal(upd *DeviceMetadataUpdated) bool {
+	return e.GetStatus().GetValue() == upd.GetStatus().GetValue() &&
+		e.GetStatus().GetValidUntil() == upd.GetStatus().GetValidUntil() &&
+		e.GetShadowSynchronization() == upd.GetShadowSynchronization() &&
+		e.GetAuditContext().GetUserId() == upd.GetAuditContext().GetUserId() &&
+		e.GetAuditContext().GetCorrelationId() == upd.GetAuditContext().GetCorrelationId()
+}

--- a/resource-aggregate/events/deviceMetadataUpdated_test.go
+++ b/resource-aggregate/events/deviceMetadataUpdated_test.go
@@ -1,0 +1,123 @@
+package events_test
+
+import (
+	"testing"
+
+	commands "github.com/plgd-dev/cloud/resource-aggregate/commands"
+	"github.com/plgd-dev/cloud/resource-aggregate/events"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeviceMetadataUpdated_Equal(t *testing.T) {
+	type fields struct {
+		Status                *commands.ConnectionStatus
+		ShadowSynchronization commands.ShadowSynchronization
+		AuditContext          *commands.AuditContext
+	}
+	type args struct {
+		upd *events.DeviceMetadataUpdated
+	}
+
+	upd := events.DeviceMetadataUpdated{
+		Status: &commands.ConnectionStatus{
+			Value:      commands.ConnectionStatus_ONLINE,
+			ValidUntil: 0,
+		},
+		ShadowSynchronization: commands.ShadowSynchronization_ENABLED,
+		AuditContext: &commands.AuditContext{
+			UserId:        "501",
+			CorrelationId: "0",
+		},
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "Identity",
+			fields: fields{
+				Status:                upd.Status,
+				ShadowSynchronization: upd.ShadowSynchronization,
+				AuditContext:          upd.AuditContext,
+			},
+			args: args{&upd},
+			want: true,
+		},
+		{
+			name: "Changed Status.Value",
+			fields: fields{
+				Status: &commands.ConnectionStatus{
+					Value:      commands.ConnectionStatus_OFFLINE,
+					ValidUntil: upd.Status.ValidUntil,
+				},
+				ShadowSynchronization: upd.ShadowSynchronization,
+				AuditContext:          upd.AuditContext,
+			},
+			args: args{&upd},
+			want: false,
+		},
+		{
+			name: "Changed Status.ValidUntil",
+			fields: fields{
+				Status: &commands.ConnectionStatus{
+					Value:      upd.Status.Value,
+					ValidUntil: upd.Status.ValidUntil + 1,
+				},
+				ShadowSynchronization: upd.ShadowSynchronization,
+				AuditContext:          upd.AuditContext,
+			},
+			args: args{&upd},
+			want: false,
+		},
+		{
+			name: "Changed ShadowSynchronization",
+			fields: fields{
+				Status:                upd.Status,
+				ShadowSynchronization: commands.ShadowSynchronization_DISABLED,
+				AuditContext:          upd.AuditContext,
+			},
+			args: args{&upd},
+			want: false,
+		},
+		{
+			name: "Changed AuditContext.UserId",
+			fields: fields{
+				Status:                upd.Status,
+				ShadowSynchronization: upd.ShadowSynchronization,
+				AuditContext: &commands.AuditContext{
+					UserId:        "502",
+					CorrelationId: upd.AuditContext.CorrelationId,
+				},
+			},
+			args: args{&upd},
+			want: false,
+		},
+		{
+			name: "Changed AuditContext.CorrelationId",
+			fields: fields{
+				Status:                upd.Status,
+				ShadowSynchronization: upd.ShadowSynchronization,
+				AuditContext: &commands.AuditContext{
+					UserId:        upd.AuditContext.UserId,
+					CorrelationId: "1",
+				},
+			},
+			args: args{&upd},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &events.DeviceMetadataUpdated{
+				Status:                tt.fields.Status,
+				ShadowSynchronization: tt.fields.ShadowSynchronization,
+				AuditContext:          tt.fields.AuditContext,
+			}
+			got := e.Equal(tt.args.upd)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/resource-aggregate/events/resourceStateSnapshotTaken.go
+++ b/resource-aggregate/events/resourceStateSnapshotTaken.go
@@ -174,17 +174,17 @@ func (e *ResourceStateSnapshotTaken) ValidateSequence(eventMetadata *EventMetada
 }
 
 func Equal(current, changed *ResourceChanged) bool {
-	if current.Status != changed.Status {
+	if current.GetStatus() != changed.GetStatus() {
 		return false
 	}
 
-	if current.Content.CoapContentFormat != changed.Content.CoapContentFormat ||
-		current.Content.ContentType != changed.Content.ContentType ||
-		!bytes.Equal(current.Content.Data, changed.Content.Data) {
+	if current.GetContent().GetCoapContentFormat() != changed.GetContent().GetCoapContentFormat() ||
+		current.GetContent().GetContentType() != changed.GetContent().GetContentType() ||
+		!bytes.Equal(current.GetContent().GetData(), changed.GetContent().GetData()) {
 		return false
 	}
 
-	if current.AuditContext.UserId != changed.AuditContext.UserId {
+	if current.GetAuditContext().GetUserId() != changed.GetAuditContext().GetUserId() {
 		return false
 	}
 

--- a/resource-directory/service/deviceMetadataProjection.go
+++ b/resource-directory/service/deviceMetadataProjection.go
@@ -149,8 +149,8 @@ func (p *deviceMetadataProjection) Handle(ctx context.Context, iter eventstore.I
 				return err
 			}
 			p.data.DeviceId = e.GetDeviceId()
-			err := p.data.HandleDeviceMetadataUpdated(ctx, &e, false)
-			if err == nil {
+			ok, _ := p.data.HandleDeviceMetadataUpdated(ctx, &e, false)
+			if ok {
 				onDeviceMetadataUpdated = true
 				onDeviceMetadataUpdatePending = true
 			}


### PR DESCRIPTION
Skip the event being handled if its equivalent to the stored
snapshot.