### PR TITLE
pkg/oauth2: update provider and token types

### DIFF
--- a/cloud2cloud-connector/service/oauthCallback.go
+++ b/cloud2cloud-connector/service/oauthCallback.go
@@ -30,7 +30,6 @@ func (rh *RequestHandler) handleLinkedData(ctx context.Context, data provisionCa
 			AccessToken:  oauth2.AccessToken(token.AccessToken),
 			Expiry:       token.Expiry,
 			RefreshToken: token.RefreshToken,
-			Owner:        "",
 		})
 		return data, nil
 	}

--- a/cloud2cloud-connector/service/service.go
+++ b/cloud2cloud-connector/service/service.go
@@ -265,7 +265,7 @@ func New(ctx context.Context, config Config, logger log.Logger) (*Server, error)
 		return nil, fmt.Errorf("cannot parse OAuth paths: %w", err)
 	}
 
-	provider, err := oauth2.NewPlgdProvider(ctx, config.APIs.HTTP.Authorization.Config, logger, config.APIs.HTTP.Authorization.OwnerClaim)
+	provider, err := oauth2.NewPlgdProvider(ctx, config.APIs.HTTP.Authorization.Config, logger)
 	if err != nil {
 		cleanUp.Execute()
 		return nil, fmt.Errorf("cannot create device provider: %w", err)

--- a/coap-gateway/service/refreshToken.go
+++ b/coap-gateway/service/refreshToken.go
@@ -148,7 +148,7 @@ func refreshTokenPostHandler(req *mux.Message, client *Client) {
 		return
 	}
 
-	owner := token.Owner
+	owner := claim.Owner(client.server.config.APIs.COAP.Authorization.OwnerClaim)
 	if owner == "" {
 		owner = refreshToken.UserID
 	}

--- a/coap-gateway/service/service.go
+++ b/coap-gateway/service/service.go
@@ -274,8 +274,7 @@ func New(ctx context.Context, config Config, logger log.Logger) (*Service, error
 	providers := make(map[string]*oauth2.PlgdProvider)
 	var firstProvider *oauth2.PlgdProvider
 	for _, p := range config.APIs.COAP.Authorization.Providers {
-		provider, err := oauth2.NewPlgdProvider(ctx, p.Config,
-			logger, config.APIs.COAP.Authorization.OwnerClaim)
+		provider, err := oauth2.NewPlgdProvider(ctx, p.Config, logger)
 		if err != nil {
 			nats.Close()
 			return nil, fmt.Errorf("cannot create device provider: %w", err)

--- a/pkg/security/oauth2/token.go
+++ b/pkg/security/oauth2/token.go
@@ -50,7 +50,6 @@ type Token struct {
 	AccessToken  AccessToken
 	RefreshToken string
 	Expiry       time.Time
-	Owner        string // can be removed if UserId parameter is removed from AddDevice/DeviceDevices calls
 }
 
 func (o Token) Refresh(ctx context.Context, cfg oauth2.Config) (Token, bool, error) {

--- a/resource-directory/service/grpcApi.go
+++ b/resource-directory/service/grpcApi.go
@@ -128,9 +128,12 @@ func newRequestHandlerFromConfig(ctx context.Context, config Config, publicConfi
 		return nil, fmt.Errorf("cannot create projection over resource aggregate events: %w", err)
 	}
 
-	ownerCache := clientIS.NewOwnerCache("sub", config.APIs.GRPC.OwnerCacheExpiration, natsClient.GetConn(), isClient, func(err error) {
-		log.Errorf("ownerCache error: %w", err)
-	})
+	ownerCache := clientIS.NewOwnerCache(config.APIs.GRPC.Authorization.OwnerClaim,
+		config.APIs.GRPC.OwnerCacheExpiration,
+		natsClient.GetConn(),
+		isClient, func(err error) {
+			log.Errorf("ownerCache error: %w", err)
+		})
 
 	h := NewRequestHandler(
 		resourceProjection,


### PR DESCRIPTION
Remove OwnerClaim from provider and Owner from token. OwnerClaim
value is available from stored configuration; owner is set in
access token.