### PR TITLE
coap-gateway: always close device subscriber

### DIFF
--- a/coap-gateway/service/signIn.go
+++ b/coap-gateway/service/signIn.go
@@ -145,7 +145,7 @@ func (client *Client) updateBySignInData(ctx context.Context, upd updateType, de
 	if upd == updateTypeChanged {
 		client.cancelResourceSubscriptions(true)
 		if err := client.closeDeviceSubscriber(); err != nil {
-			log.Errorf("failed to close previous device connection: %w", err)
+			log.Errorf("failed to close previous device subscription: %w", err)
 		}
 		if err := client.closeDeviceObserver(client.Context()); err != nil {
 			log.Errorf("failed to close previous device observer: %w", err)


### PR DESCRIPTION
DeviceSubscriber has a reconnect functionality when
connection to device is lost. However, if the device
disconnected during SignUp then the DeviceSubscriber
instance would try reconnecting forever.