### PR TITLE
grpc-gateway: add update test case

### DIFF
--- a/grpc-gateway/client/observeResource_test.go
+++ b/grpc-gateway/client/observeResource_test.go
@@ -75,6 +75,10 @@ func (h *testObservationHandler) Handle(ctx context.Context, body DecodeFunc) {
 	h.res <- body
 }
 
-func (h *testObservationHandler) Error(err error) { fmt.Println(err) }
+func (h *testObservationHandler) Error(err error) {
+	fmt.Println(err)
+}
 
-func (h *testObservationHandler) OnClose() { fmt.Println("Observation was closed") }
+func (h *testObservationHandler) OnClose() {
+	fmt.Println("Observation was closed")
+}


### PR DESCRIPTION
Add test case to verify resource data consistency after device name change.
This is a test case for iotivility-lite issue #40 oic/d piid issue with notification (https://github.com/iotivity/iotivity-lite/issues/40).