### PR TITLE
coap-gateway: log peer leaf certificate when tls handshake fails

### DIFF
--- a/pkg/log/logKeys.go
+++ b/pkg/log/logKeys.go
@@ -24,6 +24,7 @@ var ProtocolKey = "protocol"
 var BodyKey = "body"
 var DurationMSKey = "durationMs"
 var ErrorKey = "error"
+var X509Key = "x509"
 
 func DurationToMilliseconds(duration time.Duration) float32 {
 	return float32(duration.Nanoseconds()/1000) / 1000

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,10 +1,13 @@
 package log
 
 import (
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
 	"testing"
 	"time"
 
+	pkgX509 "github.com/plgd-dev/hub/v2/pkg/security/x509"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,6 +19,13 @@ func TestNew(t *testing.T) {
 
 	assert.NotPanics(t, func() { Debug(testStr) })
 	assert.NotPanics(t, func() { Info(testStr) })
+	assert.NotPanics(t, func() {
+		Info(testStr, pkgX509.NewError([][]*x509.Certificate{{&x509.Certificate{
+			Subject: pkix.Name{
+				CommonName: "certName",
+			},
+		}}}, fmt.Errorf(" x509")))
+	})
 	assert.NotPanics(t, func() { Warn(testStr) })
 	assert.NotPanics(t, func() { Error(testStr) })
 

--- a/pkg/security/x509/error.go
+++ b/pkg/security/x509/error.go
@@ -1,0 +1,56 @@
+package x509
+
+import (
+	"crypto/x509"
+	"time"
+)
+
+type Error struct {
+	chains [][]*x509.Certificate
+	err    error
+}
+
+func NewError(chains [][]*x509.Certificate, err error) *Error {
+	return &Error{chains: chains, err: err}
+}
+
+func (e *Error) Error() string {
+	return e.err.Error()
+}
+
+func (e *Error) Chains() [][]*x509.Certificate {
+	return e.chains
+}
+
+func ParseCertificate(cert *x509.Certificate) *CertificateInfo {
+	var serialNumber string
+	if cert.SerialNumber != nil {
+		serialNumber = cert.SerialNumber.String()
+	}
+	return &CertificateInfo{
+		NotBefore:          cert.NotBefore,
+		NotAfter:           cert.NotAfter,
+		SubjectName:        cert.Subject.CommonName,
+		Organization:       cert.Subject.Organization,
+		IssuerName:         cert.Issuer.CommonName,
+		IssuerOrganization: cert.Issuer.Organization,
+		SerialNumber:       serialNumber,
+	}
+}
+
+type CertificateInfo struct {
+	SubjectName        string    `json:"subjectName,omitempty"`
+	Organization       []string  `json:"organization,omitempty"`
+	IssuerName         string    `json:"issuerName,omitempty"`
+	IssuerOrganization []string  `json:"issuerOrganization,omitempty"`
+	NotAfter           time.Time `json:"notAfter,omitempty"`
+	NotBefore          time.Time `json:"notBefore,omitempty"`
+	SerialNumber       string    `json:"serialNumber,omitempty"`
+}
+
+func (e *Error) LeafCertificateInfo() *CertificateInfo {
+	if len(e.chains) == 0 || len(e.chains[0]) == 0 {
+		return nil
+	}
+	return ParseCertificate(e.chains[0][0])
+}


### PR DESCRIPTION
example:
```jsonc
{"L":"WARN","T":"2022-04-22T15:20:39.260669574Z","M":"plgd/dps: tcp: 127.0.0.1:47758: cannot send CSM: cannot write to connection: untrusted certificate","x509":{"issuerName":"issuerTest","notAfter":"2022-04-22T16:20:39Z","notBefore":"2022-04-22T14:20:39Z","serialNumber":"142123811105214257051788552604658124245","subjectName":"test"}}
```