### PR TITLE
Disable linters in golansci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,16 +63,16 @@ linters:
     # - predeclared      # find code that shadows one of Go's predeclared identifiers
     # - revive           # golint replacement, finds style mistakes
     - staticcheck      # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - structcheck      # Finds unused struct fields
-    - stylecheck       # Stylecheck is a replacement for golint
+    # - structcheck      # Finds unused struct fields
+    # - stylecheck       # Stylecheck is a replacement for golint
     # - tenv             # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
     # - tparallel        # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
     - typecheck        # Like the front-end of a Go compiler, parses and type-checks Go code
     - unconvert        # Remove unnecessary type conversions
-    - unparam          # Reports unused function parameters
+    # - unparam          # Reports unused function parameters
     - unused           # Checks Go code for unused constants, variables, functions and types
     - varcheck         # Finds unused global variables and constants
-    - wastedassign     # wastedassign finds wasted assignment statements
+    # - wastedassign     # wastedassign finds wasted assignment statements
     - whitespace       # Tool for detection of leading and trailing whitespace
   disable:
     - containedctx     # containedctx is a linter that detects struct contained context.Context field


### PR DESCRIPTION
Disable linters not yet supported by golang v1.18 in golangsci-lint