### PR TITLE
Fix grpc-gateway tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,8 @@ http-gateway-www:
 DEVICE_SIMULATOR_NAME := devsim
 DEVICE_SIMULATOR_IMG := ghcr.io/iotivity/iotivity-lite/cloud-server-debug:master
 # device with /oic/res observable
+# note: iotivity-lite runs only grpc-gateway tests and this second device is not started; thus 
+# the grpc-gateway are expected to succeed with a single non-oic/rec observable device
 DEVICE_SIMULATOR_RES_OBSERVABLE_NAME := devsim-resobs
 DEVICE_SIMULATOR_RES_OBSERVABLE_IMG := ghcr.io/iotivity/iotivity-lite/cloud-server-discovery-resource-observable-debug:master
 

--- a/grpc-gateway/service/getResourceFromDevice_test.go
+++ b/grpc-gateway/service/getResourceFromDevice_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestRequestHandlerGetResourceFromDevice(t *testing.T) {
-	deviceName := test.TestDeviceNameWithOicResObservable
+	deviceName := test.TestDeviceName
 	deviceID := test.MustFindDeviceByName(deviceName)
 	switchID := "1"
 	type args struct {


### PR DESCRIPTION
The tests in grpc-gateway are expected to use a single device with /oic/res not observable. This must be enforced so tests in iotivity-lite repository succeed.