### PR TITLE
coap-gateway: build separe image with go 1.18.8 for old mbedtls

### DIFF
--- a/.github/workflows/publishDockerImagesGhcr.yml
+++ b/.github/workflows/publishDockerImagesGhcr.yml
@@ -67,6 +67,13 @@ jobs:
           - name: cert-tool
             directory: tools/cert-tool
             file: tools/cert-tool/Dockerfile
+# coap-gateway builded by Golang 1.19.4 has an issue with TLS handshake.
+# This issue is reproducible with real devices that connect to AWS.
+# This seems to be caused by the device's old mbedtls library:
+# https://github.com/Mbed-TLS/mbedtls/tree/d81c11b8ab61fd5b2da8133aa73c5fe33a0633eb
+          - name: coap-gateway-go1-18
+            directory: coap-gateway
+            file: tools/docker/Dockerfile.go1.18
 
     permissions:
       contents: read

--- a/pkg/net/grpc/interceptor_test.go
+++ b/pkg/net/grpc/interceptor_test.go
@@ -3,6 +3,7 @@ package grpc_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/plgd-dev/hub/v2/pkg/net/grpc"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ func TestUnaryInterceptor(t *testing.T) {
 	go func() {
 		_ = svr.Serve()
 	}()
-
+	time.Sleep(100 * time.Millisecond)
 	c := StubGrpcClient(svr.Addr())
 	_, err := c.TestCall(context.Background(), &TestRequest{})
 	require.Error(t, err)
@@ -34,7 +35,7 @@ func TestStreamInterceptor(t *testing.T) {
 	go func() {
 		_ = svr.Serve()
 	}()
-
+	time.Sleep(100 * time.Millisecond)
 	c := StubGrpcClient(svr.Addr())
 	s, err := c.TestStream(context.Background())
 	require.NoError(t, err)

--- a/tools/docker/Dockerfile.go1.18
+++ b/tools/docker/Dockerfile.go1.18
@@ -1,4 +1,8 @@
-FROM golang:1.19.4-alpine AS build
+# coap-gateway builded by Golang 1.19.4 has an issue with TLS handshake.
+# This issue is reproducible with real devices that connect to AWS.
+# This seems to be caused by the device's old mbedtls library:
+# https://github.com/Mbed-TLS/mbedtls/tree/d81c11b8ab61fd5b2da8133aa73c5fe33a0633eb
+FROM golang:1.18.8-alpine AS build
 ARG DIRECTORY
 ARG NAME
 RUN apk add --no-cache curl git build-base


### PR DESCRIPTION
coap-gateway builded by Golang 1.19.4 has an issue with TLS handshake. This issue is reproducible with real devices that connect to AWS.

This seems to be caused by the device's old mbedtls library: https://github.com/Mbed-TLS/mbedtls/tree/d81c11b8ab61fd5b2da8133aa73c5fe33a0633eb