### PR TITLE
coap-gateway: use server ctx instead conn ctx during signoff

### DIFF
--- a/coap-gateway/service/observation/deviceObserver.go
+++ b/coap-gateway/service/observation/deviceObserver.go
@@ -145,7 +145,7 @@ func prepareSetupDeviceObserver(ctx context.Context, deviceID string, coapConn C
 		// the connection has been closed
 		return cfg, nil, err
 	default:
-		cfg.Logger.Debugf("cannot to get resource links from the device(%v): %w", deviceID, err)
+		cfg.Logger.Debugf("cannot to get resource links from the device(%v): %v", deviceID, err)
 		// the device doesn't have a /oic/res resource or a timeout has occurred
 		if cfg.ObservationType == ObservationType_Detect {
 			cfg.ObservationType = ObservationType_PerDevice

--- a/coap-gateway/service/signOff.go
+++ b/coap-gateway/service/signOff.go
@@ -89,25 +89,28 @@ const errFmtSignOff = "cannot handle sign off: %w"
 // Sign-off
 // https://github.com/openconnectivityfoundation/security/blob/master/swagger2.0/oic.sec.account.swagger.json
 func signOffHandler(req *mux.Message, client *session) (*pool.Message, error) {
-	err := client.blockSignOff.Acquire(req.Context(), math.MaxInt64)
-	if err != nil {
-		return nil, statusErrorf(coapCodes.ServiceUnavailable, errFmtSignOff, fmt.Errorf("cannot acquire sign off lock: some commands are in progress"))
-	}
-	defer client.blockSignOff.Release(math.MaxInt64)
-	ctx, cancel := context.WithTimeout(client.server.ctx, client.server.config.APIs.COAP.KeepAlive.Timeout)
-	defer cancel()
-
 	signOffData, err := getSignOffDataFromQuery(req)
 	if err != nil {
 		return nil, statusErrorf(coapCodes.BadOption, errFmtSignOff, err)
 	}
 
+	// we need to get signOffData because of blocking sign off, because client can close connection and clear auth context
 	signOffData = signOffData.updateSignOffDataFromAuthContext(client)
 	if err = signOffData.validateSignOffData(); err != nil {
 		return nil, statusErrorf(coapCodes.BadRequest, errFmtSignOff, err)
 	}
 
-	jwtClaims, err := client.ValidateToken(req.Context(), signOffData.accessToken)
+	// we need to use sever context because of blocking sign off, because client can close connection
+	ctx, cancel := context.WithTimeout(client.server.ctx, client.server.config.APIs.COAP.KeepAlive.Timeout)
+	defer cancel()
+
+	err = client.blockSignOff.Acquire(ctx, math.MaxInt64)
+	if err != nil {
+		return nil, statusErrorf(coapCodes.ServiceUnavailable, errFmtSignOff, fmt.Errorf("cannot acquire sign off lock: some commands are in progress"))
+	}
+	defer client.blockSignOff.Release(math.MaxInt64)
+
+	jwtClaims, err := client.ValidateToken(ctx, signOffData.accessToken)
 	if err != nil {
 		return nil, statusErrorf(coapCodes.Unauthorized, errFmtSignOff, err)
 	}


### PR DESCRIPTION
client can close connection, but we still want to try signoff device