### PR TITLE
Fix security issues reported by SonarCloud

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,8 @@
 FROM ubuntu:22.04 AS hub-test
 RUN apt-get update \
-    && DEBIAN_FRONTEND="noninteractive" apt-get install -y gcc make git curl file sudo \
+    && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends build-essential ca-certificates curl git make patch sudo \
     && curl -sSL https://get.docker.com/ | sh
+# apt: ca-certificates git make sudo
 RUN git clone https://github.com/udhos/update-golang.git \
     && cd update-golang \
     && sudo RELEASE=1.19.6 ./update-golang.sh \
@@ -15,6 +16,10 @@ WORKDIR $GOPATH/src/github.com/plgd-dev/hub/tools/cert-tool/cmd
 RUN go build -o /usr/bin/cert-tool
 
 WORKDIR $GOPATH/src/github.com/plgd-dev/hub
+# apt: patch
 RUN ( cd /usr/local/go && patch -p1 < $GOPATH/src/github.com/plgd-dev/hub/tools/docker/patches/shrink_tls_conn.patch )
+
 # RUN go mod tidy
+
+# apt: build-essential
 # RUN go test ./... || true

--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -89,7 +89,7 @@ RUN cd /web && \
     npm config set fetch-retry-mintimeout 600000 &&  \
     npm config set fetch-retry-maxtimeout 1200000 && \
     npm config set fetch-timeout 1800000 && \
-    npm install && \
+    npm install --ignore-scripts && \
     npm run build
 
 FROM ubuntu:22.04 AS service
@@ -98,13 +98,13 @@ RUN apt update
 # netcat -> nc utility in run.sh
 # nginx -> nginx server in run.sh
 # openssl -> openssl utility in run.sh
-RUN apt install -y ca-certificates gnupg iproute2 netcat nginx openssl wget
+RUN apt-get install -y --no-install-recommends ca-certificates gnupg iproute2 netcat nginx openssl wget
 # yq utility in run.sh
 RUN wget https://github.com/mikefarah/yq/releases/download/v4.6.3/yq_linux_$(dpkg --print-architecture) -O /usr/bin/yq && chmod +x /usr/bin/yq
 RUN wget -qO - https://pgp.mongodb.com/server-6.0.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/mongodb-6.0.gpg
 RUN echo "deb [ arch=$(dpkg --print-architecture) ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list
 RUN apt update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y mongodb-org mongodb-org-server
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends mongodb-org mongodb-org-server
 COPY --from=build /go/bin/coap-gateway /usr/local/bin/coap-gateway
 COPY --from=build /go/src/github.com/plgd-dev/hub/coap-gateway/config.yaml /configs/coap-gateway.yaml
 COPY --from=build /go/bin/grpc-gateway /usr/local/bin/grpc-gateway

--- a/http-gateway/Dockerfile
+++ b/http-gateway/Dockerfile
@@ -17,7 +17,7 @@ RUN cd /web && \
     npm config set fetch-retry-mintimeout 600000 &&  \
     npm config set fetch-retry-maxtimeout 1200000 && \
     npm config set fetch-timeout 1800000 && \
-    npm install && \
+    npm install --ignore-scripts && \
     npm run build
 
 FROM alpine:3.17 AS security-provider

--- a/test/cloud-server/Dockerfile
+++ b/test/cloud-server/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.19.6-alpine AS build
-RUN apk add --no-cache curl git build-base
+RUN apk add --no-cache build-base curl git
 WORKDIR $GOPATH/src/github.com/plgd-dev/hub
 COPY go.mod go.sum ./
 RUN go mod download
@@ -48,11 +48,11 @@ RUN apt update
 # netcat -> nc utility in run.sh
 # nginx -> nginx server in run.sh
 # openssl -> openssl utility in run.sh
-RUN apt install -y ca-certificates gnupg iproute2 netcat nginx openssl wget
+RUN apt-get install -y --no-install-recommends ca-certificates gnupg iproute2 netcat nginx openssl wget
 RUN wget -qO - https://pgp.mongodb.com/server-6.0.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/mongodb-6.0.gpg
 RUN echo "deb [ arch=$(dpkg --print-architecture) ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list
 RUN apt update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y mongodb-org mongodb-org-server
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends mongodb-org mongodb-org-server
 COPY --from=build /go/bin/cert-tool /usr/local/bin/cert-tool
 COPY --from=build /go/bin/grpc-gateway.test /usr/local/bin/grpc-gateway.test
 COPY --from=build /go/bin/test-iotivity-lite.test /usr/local/bin/test-iotivity-lite.test


### PR DESCRIPTION
Avoid installing package dependencies that are not strictly required by apt and npm in Dockerfiles.