### PR TITLE
Fix typo: WithValididity -> WithValidity

### DIFF
--- a/test/sdkclient.go
+++ b/test/sdkclient.go
@@ -83,9 +83,9 @@ func WithRootCA(certificate, key []byte) Option {
 	})
 }
 
-// WithValididity creates Option that overrides the ValidFrom timestamp and CertExpiry
+// WithValidity creates Option that overrides the ValidFrom timestamp and CertExpiry
 // interval used by the SDK client when generating certificates.
-func WithValididity(validFrom, validFor string) Option {
+func WithValidity(validFrom, validFor string) Option {
 	return optionFunc(func(cfg *sdkConfig) {
 		cfg.validFrom = validFrom
 		cfg.validFor = validFor


### PR DESCRIPTION
This fixes commit: ce60d666342996a72ed8b7de37a73f9f79cbcd2c