### PR TITLE
coap-gateway: Correct online_valid_until for tokens without expiration

### DIFF
--- a/coap-gateway/service/devicesStatusUpdater.go
+++ b/coap-gateway/service/devicesStatusUpdater.go
@@ -77,7 +77,8 @@ func (u *devicesStatusUpdater) updateOnlineStatus(ctx context.Context, client *s
 		return nil, time.Time{}, err
 	}
 	ctx = kitNetGrpc.CtxWithToken(ctx, authCtx.GetAccessToken())
-	if !u.cfg.Enabled || authCtx.Expire.UnixNano() < validUntil.UnixNano() {
+	// When authCtx.Expire is zero, the token will never expire
+	if !u.cfg.Enabled || (!authCtx.Expire.IsZero() && authCtx.Expire.UnixNano() < validUntil.UnixNano()) {
 		validUntil = authCtx.Expire
 	}
 	resp, err := client.server.raClient.UpdateDeviceMetadata(ctx, &commands.UpdateDeviceMetadataRequest{

--- a/coap-gateway/service/devicesStatusUpdater_test.go
+++ b/coap-gateway/service/devicesStatusUpdater_test.go
@@ -1,0 +1,136 @@
+package service_test
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	coapService "github.com/plgd-dev/hub/v2/coap-gateway/service"
+	coapgwTest "github.com/plgd-dev/hub/v2/coap-gateway/test"
+	"github.com/plgd-dev/hub/v2/grpc-gateway/pb"
+	kitNetGrpc "github.com/plgd-dev/hub/v2/pkg/net/grpc"
+	"github.com/plgd-dev/hub/v2/resource-aggregate/commands"
+	test "github.com/plgd-dev/hub/v2/test"
+	"github.com/plgd-dev/hub/v2/test/config"
+	oauthService "github.com/plgd-dev/hub/v2/test/oauth-server/service"
+	oauthTest "github.com/plgd-dev/hub/v2/test/oauth-server/test"
+	"github.com/plgd-dev/hub/v2/test/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+func onboardDeviceAndGetDevice(ctx context.Context, t *testing.T, deviceID string, oauthCfg oauthService.Config, coapCfg coapService.Config) (*pb.Device, time.Time /*startOnboard*/, time.Duration /*delta*/) {
+	tearDown := service.SetUp(ctx, t, service.WithOAuthConfig(oauthCfg), service.WithCOAPGWConfig(coapCfg))
+	defer tearDown()
+	ctx = kitNetGrpc.CtxWithToken(ctx, oauthTest.GetDefaultAccessToken(t))
+
+	conn, err := grpc.Dial(config.GRPC_GW_HOST, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+		RootCAs: test.GetRootCertificatePool(t),
+	})))
+	require.NoError(t, err)
+	defer func() {
+		_ = conn.Close()
+	}()
+	c := pb.NewGrpcGatewayClient(conn)
+
+	startOnboard := time.Now()
+	_, shutdownDevSim := test.OnboardDevSim(ctx, t, c, deviceID, config.ACTIVE_COAP_SCHEME+"://"+config.COAP_GW_HOST, test.GetAllBackendResourceLinks())
+	defer shutdownDevSim()
+	deltaOnboard := time.Since(startOnboard) / 2
+
+	// for update resource-directory cache
+	time.Sleep(time.Second)
+
+	client, err := c.GetDevices(ctx, &pb.GetDevicesRequest{})
+	require.NoError(t, err)
+	devices := make([]*pb.Device, 0, 1)
+	for {
+		dev, err := client.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		assert.NotEmpty(t, dev.ProtocolIndependentId)
+		dev.ProtocolIndependentId = ""
+		devices = append(devices, dev)
+	}
+	require.Len(t, devices, 1)
+	return devices[0], startOnboard, deltaOnboard
+}
+
+func TestDevicesStatusUpdaterEnabledAndDeviceAccessTokenHasNoExpiration(t *testing.T) {
+	deviceID := test.MustFindDeviceByName(test.TestDeviceName)
+	ctx, cancel := context.WithTimeout(context.Background(), config.TEST_TIMEOUT)
+	defer cancel()
+
+	oauthCfg := oauthTest.MakeConfig(t)
+	oauthCfg.OAuthSigner.Clients.Find(config.OAUTH_MANAGER_CLIENT_ID).AccessTokenLifetime = 0
+	coapCfg := coapgwTest.MakeConfig(t)
+	expiresIn := time.Second * 20
+	coapCfg.Clients.ResourceAggregate.DeviceStatusExpiration.Enabled = true
+	coapCfg.Clients.ResourceAggregate.DeviceStatusExpiration.ExpiresIn = expiresIn
+
+	device, startOnboard, deltaOnboard := onboardDeviceAndGetDevice(ctx, t, deviceID, oauthCfg, coapCfg)
+	expectedOnlineValidUntil := startOnboard.Add(expiresIn + deltaOnboard).UnixNano()
+
+	assert.Equal(t, commands.Connection_ONLINE, device.Metadata.Connection.Status)
+	assert.InDelta(t, expectedOnlineValidUntil, device.Metadata.Connection.OnlineValidUntil, float64(deltaOnboard))
+}
+
+func TestDevicesStatusUpdaterDisabledAndDeviceAccessTokenHasNoExpiration(t *testing.T) {
+	deviceID := test.MustFindDeviceByName(test.TestDeviceName)
+	ctx, cancel := context.WithTimeout(context.Background(), config.TEST_TIMEOUT)
+	defer cancel()
+
+	oauthCfg := oauthTest.MakeConfig(t)
+	oauthCfg.OAuthSigner.Clients.Find(config.OAUTH_MANAGER_CLIENT_ID).AccessTokenLifetime = 0
+	coapCfg := coapgwTest.MakeConfig(t)
+	coapCfg.Clients.ResourceAggregate.DeviceStatusExpiration.Enabled = false
+
+	device, _, _ := onboardDeviceAndGetDevice(ctx, t, deviceID, oauthCfg, coapCfg)
+
+	assert.Equal(t, commands.Connection_ONLINE, device.Metadata.Connection.Status)
+	assert.Equal(t, int64(0), device.Metadata.Connection.OnlineValidUntil)
+}
+
+func TestDevicesStatusUpdaterDisabledAndDeviceAccessTokenHasExpiration(t *testing.T) {
+	deviceID := test.MustFindDeviceByName(test.TestDeviceName)
+	ctx, cancel := context.WithTimeout(context.Background(), config.TEST_TIMEOUT)
+	defer cancel()
+
+	oauthCfg := oauthTest.MakeConfig(t)
+	accessTokenLifetime := time.Second * 10
+	oauthCfg.OAuthSigner.Clients.Find(config.OAUTH_MANAGER_CLIENT_ID).AccessTokenLifetime = accessTokenLifetime
+	coapCfg := coapgwTest.MakeConfig(t)
+	coapCfg.Clients.ResourceAggregate.DeviceStatusExpiration.Enabled = false
+
+	device, startOnboard, deltaOnboard := onboardDeviceAndGetDevice(ctx, t, deviceID, oauthCfg, coapCfg)
+	expectedOnlineValidUntil := startOnboard.Add(accessTokenLifetime + deltaOnboard).UnixNano()
+
+	assert.Equal(t, commands.Connection_ONLINE, device.Metadata.Connection.Status)
+	assert.InDelta(t, expectedOnlineValidUntil, device.Metadata.Connection.OnlineValidUntil, float64(deltaOnboard))
+}
+
+func TestDevicesStatusUpdaterEnabledAndDeviceAccessTokenHasExpiration(t *testing.T) {
+	deviceID := test.MustFindDeviceByName(test.TestDeviceName)
+	ctx, cancel := context.WithTimeout(context.Background(), config.TEST_TIMEOUT)
+	defer cancel()
+
+	oauthCfg := oauthTest.MakeConfig(t)
+	oauthCfg.OAuthSigner.Clients.Find(config.OAUTH_MANAGER_CLIENT_ID).AccessTokenLifetime = time.Hour
+	coapCfg := coapgwTest.MakeConfig(t)
+	expiresIn := time.Second * 20
+	coapCfg.Clients.ResourceAggregate.DeviceStatusExpiration.Enabled = true
+	coapCfg.Clients.ResourceAggregate.DeviceStatusExpiration.ExpiresIn = expiresIn
+
+	device, startOnboard, deltaOnboard := onboardDeviceAndGetDevice(ctx, t, deviceID, oauthCfg, coapCfg)
+	expectedOnlineValidUntil := startOnboard.Add(expiresIn + deltaOnboard).UnixNano()
+
+	assert.Equal(t, commands.Connection_ONLINE, device.Metadata.Connection.Status)
+	assert.InDelta(t, expectedOnlineValidUntil, device.Metadata.Connection.OnlineValidUntil, float64(deltaOnboard))
+}

--- a/test/service/service.go
+++ b/test/service/service.go
@@ -22,6 +22,7 @@ import (
 	rdService "github.com/plgd-dev/hub/v2/resource-directory/service"
 	rdTest "github.com/plgd-dev/hub/v2/resource-directory/test"
 	"github.com/plgd-dev/hub/v2/test/config"
+	oauthService "github.com/plgd-dev/hub/v2/test/oauth-server/service"
 	oauthTest "github.com/plgd-dev/hub/v2/test/oauth-server/test"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
@@ -74,6 +75,7 @@ type Config struct {
 	RA     raService.Config
 	IS     isService.Config
 	CA     ca.Config
+	OAUTH  oauthService.Config
 }
 
 func WithCOAPGWConfig(coapgwCfg coapgw.Config) SetUpOption {
@@ -112,6 +114,12 @@ func WithCAConfig(ca ca.Config) SetUpOption {
 	}
 }
 
+func WithOAuthConfig(oauth oauthService.Config) SetUpOption {
+	return func(cfg *Config) {
+		cfg.OAUTH = oauth
+	}
+}
+
 type SetUpOption = func(cfg *Config)
 
 func SetUp(ctx context.Context, t require.TestingT, opts ...SetUpOption) (tearDown func()) {
@@ -122,6 +130,7 @@ func SetUp(ctx context.Context, t require.TestingT, opts ...SetUpOption) (tearDo
 		RA:     raTest.MakeConfig(t),
 		IS:     isTest.MakeConfig(t),
 		CA:     caService.MakeConfig(t),
+		OAUTH:  oauthTest.MakeConfig(t),
 	}
 
 	for _, o := range opts {
@@ -129,7 +138,7 @@ func SetUp(ctx context.Context, t require.TestingT, opts ...SetUpOption) (tearDo
 	}
 
 	ClearDB(ctx, t)
-	oauthShutdown := oauthTest.SetUp(t)
+	oauthShutdown := oauthTest.New(t, config.OAUTH)
 	isShutdown := isTest.New(t, config.IS)
 	raShutdown := raTest.New(t, config.RA)
 	rdShutdown := rdTest.New(t, config.RD)

--- a/test/test.go
+++ b/test/test.go
@@ -586,6 +586,7 @@ func WaitForDevice(t *testing.T, client pb.GrpcGateway_SubscribeToEventsClient, 
 				val.DeviceMetadataUpdated.GetConnection().Id = ""
 				require.NotZero(t, val.DeviceMetadataUpdated.GetConnection().GetConnectedAt())
 				val.DeviceMetadataUpdated.GetConnection().ConnectedAt = 0
+				val.DeviceMetadataUpdated.GetConnection().OnlineValidUntil = 0
 			}
 			if val.DeviceMetadataUpdated.GetTwinSynchronization() != nil {
 				val.DeviceMetadataUpdated.GetTwinSynchronization().CommandMetadata = nil


### PR DESCRIPTION
Fixes #997

When a token is assigned an expiration value of 0, it indicates that the token does not have an expiration. In such cases, the connection's online validity should be set according to the configuration in `deviceStatusExpiration.expiresIn`, but only if
`deviceStatusExpiration.enabled` is set to true.