### PR TITLE
bundle: allow bundling to utilize setup from the previous run

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -134,6 +134,7 @@ COPY --from=build /go/src/github.com/plgd-dev/hub/bundle/nginx /nginx
 ENV FQDN="localhost"
 ENV LOG_DEBUG=false
 ENV JETSTREAM=false
+ENV OVERRIDE_FILES=false
 
 # global - open telemetry collector client
 ENV OPEN_TELEMETRY_EXPORTER_ENABLED=false


### PR DESCRIPTION
In cases where the a config file does not exist, the bundling process will attempt to generate it. All generated files are stored within the "/data" directory. By utilizing a volume on this directory, you can reuse the generated files for subsequent runs. If you wish to regenerate all files, you can set the environment variable "OVERRIDE_FILES" to "true".