### PR TITLE
coap-gateway: allow to use device redirect uri for signup

### DIFF
--- a/charts/plgd-hub/templates/coap-gateway/config.yaml
+++ b/charts/plgd-hub/templates/coap-gateway/config.yaml
@@ -64,6 +64,7 @@ data:
           {{- end }}
           {{- range $providers }}
             - name: {{ required "name for oauth device provider is required" .name | quote }}
+              useDeviceRedirectURL: {{ .useDeviceRedirectURL | default false }}
               clientID: {{ required "clientID for oauth device provider is required" .clientID | quote }}
               clientSecretFile: {{ include "plgd-hub.oauthSecretFile" (list $ . ) }}
               {{- if .grantType }}

--- a/charts/plgd-hub/values.yaml
+++ b/charts/plgd-hub/values.yaml
@@ -20,6 +20,7 @@ global:
   oauth:
    device: []
 #     - name:
+#       useDeviceRedirectURL: false
 #       clientID:
 #       clientSecret:
 #       scopes: []

--- a/cloud2cloud-connector/service/oauthCallback.go
+++ b/cloud2cloud-connector/service/oauthCallback.go
@@ -11,7 +11,7 @@ import (
 
 func (rh *RequestHandler) handleLinkedData(ctx context.Context, data ProvisionCacheData, authCode string) (ProvisionCacheData, error) {
 	if !data.linkedAccount.Data.HasOrigin() {
-		token, err := rh.provider.Exchange(ctx, authCode)
+		token, err := rh.provider.Exchange(ctx, authCode, "")
 		if err != nil {
 			return data, fmt.Errorf("cannot exchange origin cloud authorization code for access token: %w", err)
 		}

--- a/coap-gateway/config.yaml
+++ b/coap-gateway/config.yaml
@@ -37,6 +37,7 @@ apis:
       deviceIDClaim: ""
       providers:
         - name: "plgd.web"
+          useDeviceRedirectURL: false
           clientID: ""
           clientSecretFile: ""
           scopes: []
@@ -56,6 +57,7 @@ apis:
               certFile: "/secrets/public/cert.crt"
               useSystemCAPool: false
         - name: "plgd.mobile"
+          useDeviceRedirectURL: false
           clientID: ""
           clientSecretFile: ""
           scopes: []

--- a/coap-gateway/service/config.go
+++ b/coap-gateway/service/config.go
@@ -55,8 +55,9 @@ func (c *APIsConfig) Validate() error {
 }
 
 type ProvidersConfig struct {
-	Name          string `yaml:"name" json:"name"`
-	oauth2.Config `yaml:",inline"`
+	Name                 string `yaml:"name" json:"name"`
+	UseDeviceRedirectURL bool   `yaml:"useDeviceRedirectURL" json:"useDeviceRedirectURL"`
+	oauth2.Config        `yaml:",inline"`
 }
 
 func (c *ProvidersConfig) Validate(firstAuthority string, providerNames map[string]bool) error {

--- a/coap-gateway/service/exchangeCache.go
+++ b/coap-gateway/service/exchangeCache.go
@@ -38,7 +38,7 @@ func (e *ExchangeCache) getFutureToken(authorizationCode string) (*future.Future
 }
 
 // Execute Exchange or returned cached value.
-func (e *ExchangeCache) Execute(ctx context.Context, provider *oauth2.PlgdProvider, authorizationCode string) (*oauth2.Token, error) {
+func (e *ExchangeCache) Execute(ctx context.Context, provider *Provider, authorizationCode string, redirectURI string) (*oauth2.Token, error) {
 	if authorizationCode == "" {
 		return nil, fmt.Errorf("invalid authorization code")
 	}
@@ -53,7 +53,7 @@ func (e *ExchangeCache) Execute(ctx context.Context, provider *oauth2.PlgdProvid
 		return v.(*oauth2.Token), nil
 	}
 
-	token, err := provider.Exchange(ctx, authorizationCode)
+	token, err := provider.Exchange(ctx, authorizationCode, redirectURI)
 	set(token, err)
 	if err != nil {
 		return nil, err

--- a/coap-gateway/service/refreshCache.go
+++ b/coap-gateway/service/refreshCache.go
@@ -27,7 +27,7 @@ func NewRefreshCache() *RefreshCache {
 	return &RefreshCache{}
 }
 
-func refresh(ctx context.Context, providers map[string]*oauth2.PlgdProvider, queue *queue.Queue, refreshToken string, logger log.Logger) (*oauth2.Token, error) {
+func refresh(ctx context.Context, providers map[string]*Provider, queue *queue.Queue, refreshToken string, logger log.Logger) (*oauth2.Token, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	var wg sync.WaitGroup
@@ -36,7 +36,7 @@ func refresh(ctx context.Context, providers map[string]*oauth2.PlgdProvider, que
 	var err error
 	for name, p := range providers {
 		wg.Add(1)
-		task := func(provider *oauth2.PlgdProvider) func() {
+		task := func(provider *Provider) func() {
 			return func() {
 				defer wg.Done()
 				tokenTmp, errTmp := provider.Refresh(ctx, refreshToken)
@@ -81,7 +81,7 @@ func (r *RefreshCache) getFutureToken(refreshToken string) (*future.Future, futu
 	return r.token, nil
 }
 
-func (r *RefreshCache) Execute(ctx context.Context, providers map[string]*oauth2.PlgdProvider, queue *queue.Queue, refreshToken string, logger log.Logger) (*oauth2.Token, error) {
+func (r *RefreshCache) Execute(ctx context.Context, providers map[string]*Provider, queue *queue.Queue, refreshToken string, logger log.Logger) (*oauth2.Token, error) {
 	if refreshToken == "" {
 		return nil, fmt.Errorf("invalid refreshToken")
 	}

--- a/coap-gateway/service/signUp.go
+++ b/coap-gateway/service/signUp.go
@@ -20,6 +20,7 @@ type CoapSignUpRequest struct {
 	AuthorizationCode       string `json:"accesstoken"`
 	AuthorizationCodeLegacy string `json:"authcode"`
 	AuthorizationProvider   string `json:"authprovider"`
+	RedirectURI             string `json:"redirecturi"`
 }
 
 type CoapSignUpResponse struct {
@@ -86,8 +87,12 @@ func signUpPostHandler(req *mux.Message, client *session) (*pool.Message, error)
 	if !ok {
 		return nil, statusErrorf(coapCodes.Unauthorized, errFmtSignUP, fmt.Errorf("unknown authorization provider('%v')", signUp.AuthorizationProvider))
 	}
+	redirectURI := ""
+	if provider.UseDeviceRedirectURL {
+		redirectURI = signUp.RedirectURI
+	}
 
-	token, err := client.exchangeCache.Execute(req.Context(), provider, signUp.AuthorizationCode)
+	token, err := client.exchangeCache.Execute(req.Context(), provider, signUp.AuthorizationCode, redirectURI)
 	if err != nil {
 		// When OAuth server is not accessible, then return 503 Service Unavailable. If real error occurs them http code is mapped to code.
 		return nil, statusErrorf(coapCodes.ServiceUnavailable, errFmtSignUP, err)

--- a/pkg/security/oauth2/plgd.go
+++ b/pkg/security/oauth2/plgd.go
@@ -14,7 +14,7 @@ import (
 )
 
 type provider interface {
-	Exchange(ctx context.Context, authorizationCode string) (*Token, error)
+	Exchange(ctx context.Context, authorizationCode, redirectURI string) (*Token, error)
 	Refresh(ctx context.Context, refreshToken string) (*Token, error)
 	HTTP() *http.Client
 	Close()

--- a/pkg/security/oauth2/plgd_authcode.go
+++ b/pkg/security/oauth2/plgd_authcode.go
@@ -23,10 +23,13 @@ type AuthCodePlgdProvider struct {
 }
 
 // Exchange Auth Code for Access Token via OAuth
-func (p *AuthCodePlgdProvider) Exchange(ctx context.Context, authorizationCode string) (*Token, error) {
+func (p *AuthCodePlgdProvider) Exchange(ctx context.Context, authorizationCode string, redirectURI string) (*Token, error) {
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, p.HTTPClient.HTTP())
 
 	oauth := p.Config.ToDefaultOAuth2()
+	if redirectURI != "" {
+		oauth.RedirectURL = redirectURI
+	}
 	token, err := oauth.Exchange(ctx, authorizationCode)
 	if err != nil {
 		return nil, err

--- a/pkg/security/oauth2/plgd_clientCrendetials.go
+++ b/pkg/security/oauth2/plgd_clientCrendetials.go
@@ -34,7 +34,7 @@ type ClientCredentialsPlgdProvider struct {
 }
 
 // Exchange Auth Code for Access Token via OAuth
-func (p *ClientCredentialsPlgdProvider) Exchange(ctx context.Context, authorizationCode string) (*Token, error) {
+func (p *ClientCredentialsPlgdProvider) Exchange(ctx context.Context, authorizationCode string, _ string) (*Token, error) {
 	claims, err := p.jwtValidator.ParseWithContext(ctx, authorizationCode)
 	if err != nil {
 		return nil, fmt.Errorf("cannot verify authorization code: %w", err)
@@ -68,7 +68,7 @@ func (p *ClientCredentialsPlgdProvider) Exchange(ctx context.Context, authorizat
 
 // Refresh gets new Access Token via OAuth.
 func (p *ClientCredentialsPlgdProvider) Refresh(ctx context.Context, refreshToken string) (*Token, error) {
-	return p.Exchange(ctx, refreshToken)
+	return p.Exchange(ctx, refreshToken, "")
 }
 
 func (p *ClientCredentialsPlgdProvider) Close() {


### PR DESCRIPTION
For a confidential OAuth client (e.g., server-side application), the client application must protect the client ID and client secret, which are used during the token request to authenticate the client to the authorization server. For redirect URI it is optional.

In summary, the redirect URI itself is not a secret parameter in the authorization code flow so it can be propagated to the device and used in register action to the cloud.

This allows to have one provider in the cloud. Otherwise you need to have provider for each redirect_uri.