### PR TITLE
certificate-authority: allow sets external caPool to signer for k8s

### DIFF
--- a/certificate-authority/config.yaml
+++ b/certificate-authority/config.yaml
@@ -84,6 +84,7 @@ clients:
         certFile: "/secrets/public/cert.crt"
         useSystemCAPool: false
 signer:
+  caPool: "/secrets/public/rootca.crt"
   keyFile: "/secrets/private/intermediateca.key"
   certFile: "/secrets/public/intermediateca.crt"
   validFrom: "now-1h"

--- a/certificate-authority/service/cleanDatabase_test.go
+++ b/certificate-authority/service/cleanDatabase_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/plgd-dev/hub/v2/certificate-authority/store"
 	"github.com/plgd-dev/hub/v2/certificate-authority/test"
 	"github.com/plgd-dev/hub/v2/identity-store/events"
+	"github.com/plgd-dev/hub/v2/pkg/fsnotify"
 	"github.com/plgd-dev/hub/v2/pkg/log"
 	kitNetGrpc "github.com/plgd-dev/hub/v2/pkg/net/grpc"
 	"github.com/plgd-dev/hub/v2/test/config"
@@ -54,9 +55,20 @@ func TestCertificateAuthorityServerCleanUpSigningRecords(t *testing.T) {
 	err := store.CreateSigningRecord(context.Background(), r)
 	require.NoError(t, err)
 
-	ch := new(inprocgrpc.Channel)
-	ca, err := grpc.NewCertificateAuthorityServer(ownerClaim, config.HubID(), test.MakeConfig(t).Signer, store, log.NewLogger(log.MakeDefaultConfig()))
+	logger := log.NewLogger(log.MakeDefaultConfig())
+
+	fileWatcher, err := fsnotify.NewWatcher(logger)
 	require.NoError(t, err)
+	defer func() {
+		err = fileWatcher.Close()
+		require.NoError(t, err)
+	}()
+
+	ch := new(inprocgrpc.Channel)
+	ca, err := grpc.NewCertificateAuthorityServer(ownerClaim, config.HubID(), test.MakeConfig(t).Signer, store, fileWatcher, logger)
+	require.NoError(t, err)
+	defer ca.Close()
+
 	pb.RegisterCertificateAuthorityServer(ch, ca)
 	grpcClient := pb.NewCertificateAuthorityClient(ch)
 	token := config.CreateJwtToken(t, jwt.MapClaims{

--- a/certificate-authority/service/config.go
+++ b/certificate-authority/service/config.go
@@ -39,6 +39,12 @@ func (c *Config) Validate() error {
 	if _, err := uuid.Parse(c.HubID); err != nil {
 		return fmt.Errorf("hubID('%v') - %w", c.HubID, err)
 	}
+
+	_, err := grpcService.NewSigner(c.APIs.GRPC.Authorization.OwnerClaim, c.HubID, c.Signer)
+	if err != nil {
+		return fmt.Errorf("signer('%v') - %w", c.Signer, err)
+	}
+
 	return nil
 }
 

--- a/certificate-authority/service/grpc/getSigningRecords_test.go
+++ b/certificate-authority/service/grpc/getSigningRecords_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/plgd-dev/hub/v2/certificate-authority/store"
 	"github.com/plgd-dev/hub/v2/certificate-authority/test"
 	"github.com/plgd-dev/hub/v2/identity-store/events"
+	"github.com/plgd-dev/hub/v2/pkg/fsnotify"
 	"github.com/plgd-dev/hub/v2/pkg/log"
 	kitNetGrpc "github.com/plgd-dev/hub/v2/pkg/net/grpc"
 	hubTest "github.com/plgd-dev/hub/v2/test"
@@ -75,9 +76,20 @@ func TestCertificateAuthorityServerGetSigningRecords(t *testing.T) {
 	err := store.CreateSigningRecord(context.Background(), r)
 	require.NoError(t, err)
 
-	ch := new(inprocgrpc.Channel)
-	ca, err := grpc.NewCertificateAuthorityServer(ownerClaim, config.HubID(), test.MakeConfig(t).Signer, store, log.NewLogger(log.MakeDefaultConfig()))
+	logger := log.NewLogger(log.MakeDefaultConfig())
+
+	fileWatcher, err := fsnotify.NewWatcher(logger)
 	require.NoError(t, err)
+	defer func() {
+		err = fileWatcher.Close()
+		require.NoError(t, err)
+	}()
+
+	ch := new(inprocgrpc.Channel)
+	ca, err := grpc.NewCertificateAuthorityServer(ownerClaim, config.HubID(), test.MakeConfig(t).Signer, store, fileWatcher, logger)
+	require.NoError(t, err)
+	defer ca.Close()
+
 	pb.RegisterCertificateAuthorityServer(ch, ca)
 	grpcClient := pb.NewCertificateAuthorityClient(ch)
 	token := config.CreateJwtToken(t, jwt.MapClaims{

--- a/certificate-authority/service/grpc/server_test.go
+++ b/certificate-authority/service/grpc/server_test.go
@@ -1,0 +1,119 @@
+package grpc_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/plgd-dev/device/v2/pkg/security/generateCertificate"
+	"github.com/plgd-dev/hub/v2/certificate-authority/service/grpc"
+	"github.com/plgd-dev/hub/v2/certificate-authority/test"
+	"github.com/plgd-dev/hub/v2/pkg/fsnotify"
+	"github.com/plgd-dev/hub/v2/pkg/log"
+	"github.com/plgd-dev/hub/v2/test/config"
+	"github.com/stretchr/testify/require"
+)
+
+func createCACertificate(t *testing.T) ([]byte, *ecdsa.PrivateKey) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	var cfg generateCertificate.Configuration
+	cfg.Subject.CommonName = "rootCA"
+	cfg.ValidFor = time.Hour * 24
+	cfg.BasicConstraints.MaxPathLen = 1000
+	rootCA, err := generateCertificate.GenerateRootCA(cfg, priv)
+	require.NoError(t, err)
+	return rootCA, priv
+}
+
+func privateKeyToPem(t *testing.T, priv *ecdsa.PrivateKey) []byte {
+	privKey, err := x509.MarshalECPrivateKey(priv)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: privKey})
+}
+
+func TestReloadCerts(t *testing.T) {
+	const ownerClaim = "sub"
+	store, closeStore := test.NewMongoStore(t)
+	defer closeStore()
+
+	logCfg := log.MakeDefaultConfig()
+	logCfg.Level = log.DebugLevel
+	logger := log.NewLogger(log.MakeDefaultConfig())
+
+	fileWatcher, err := fsnotify.NewWatcher(logger)
+	require.NoError(t, err)
+	defer func() {
+		err = fileWatcher.Close()
+		require.NoError(t, err)
+	}()
+
+	crt, err := os.CreateTemp("", "TestReloadCerts***.crt")
+	require.NoError(t, err)
+	defer func() {
+		err = os.Remove(crt.Name())
+		require.NoError(t, err)
+	}()
+	err = crt.Close()
+	require.NoError(t, err)
+
+	key, err := os.CreateTemp("", "TestReloadCerts***.key")
+	require.NoError(t, err)
+	defer func() {
+		err = os.Remove(key.Name())
+		require.NoError(t, err)
+	}()
+	err = key.Close()
+	require.NoError(t, err)
+
+	crtPem, privKey := createCACertificate(t)
+	err = os.WriteFile(crt.Name(), crtPem, 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(key.Name(), privateKeyToPem(t, privKey), 0o600)
+	require.NoError(t, err)
+
+	s := test.MakeConfig(t).Signer
+	s.CAPool = []string{crt.Name()}
+	s.CertFile = crt.Name()
+	s.KeyFile = key.Name()
+	err = s.Validate()
+	require.NoError(t, err)
+
+	ca, err := grpc.NewCertificateAuthorityServer(ownerClaim, config.HubID(), s, store, fileWatcher, logger)
+	require.NoError(t, err)
+	defer ca.Close()
+
+	// test reload certs with the different certs
+
+	s1 := ca.GetSigner()
+
+	crtPem, privKey = createCACertificate(t)
+	err = os.WriteFile(crt.Name(), crtPem, 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(key.Name(), privateKeyToPem(t, privKey), 0o600)
+	require.NoError(t, err)
+
+	// wait for reload certs
+	time.Sleep(time.Second)
+
+	s2 := ca.GetSigner()
+	require.NotEqual(t, s1, s2)
+
+	// test reload certs with the same certs
+
+	err = os.WriteFile(crt.Name(), crtPem, 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(key.Name(), privateKeyToPem(t, privKey), 0o600)
+	require.NoError(t, err)
+
+	// wait for reload certs
+	time.Sleep(time.Second)
+
+	s3 := ca.GetSigner()
+	require.Equal(t, s2, s3)
+}

--- a/certificate-authority/service/grpc/signer.go
+++ b/certificate-authority/service/grpc/signer.go
@@ -1,0 +1,162 @@
+package grpc
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/karrick/tparse/v2"
+	"github.com/plgd-dev/hub/v2/certificate-authority/pb"
+	"github.com/plgd-dev/hub/v2/pkg/security/certificateSigner"
+	"github.com/plgd-dev/kit/v2/security"
+)
+
+type Signer struct {
+	validFrom   func() time.Time
+	validFor    time.Duration
+	certificate []*x509.Certificate
+	privateKey  crypto.PrivateKey
+	ownerClaim  string
+	hubID       string
+}
+
+func isRootCA(cert *x509.Certificate) bool {
+	return cert.IsCA && bytes.Equal(cert.RawIssuer, cert.RawSubject) && cert.CheckSignature(cert.SignatureAlgorithm, cert.RawTBSCertificate, cert.Signature) == nil
+}
+
+func setCAPools(roots *x509.CertPool, intermediates *x509.CertPool, certs []*x509.Certificate) {
+	for _, cert := range certs {
+		if !cert.IsCA {
+			continue
+		}
+		if isRootCA(cert) {
+			roots.AddCert(cert)
+			continue
+		}
+		intermediates.AddCert(cert)
+	}
+}
+
+func checkCertificatePrivateKey(cert []*x509.Certificate, priv *ecdsa.PrivateKey) error {
+	if len(cert) == 0 {
+		return fmt.Errorf("at least one certificate need to be set")
+	}
+	x509Cert := cert[0]
+	switch pub := x509Cert.PublicKey.(type) {
+	case *ecdsa.PublicKey:
+		if pub.X.Cmp(priv.X) != 0 || pub.Y.Cmp(priv.Y) != 0 {
+			return errors.New("private key does not match public key")
+		}
+	default:
+		return errors.New("unknown public key algorithm")
+	}
+	return nil
+}
+
+func NewSigner(ownerClaim string, hubID string, signerConfig SignerConfig) (*Signer, error) {
+	certificate, err := security.LoadX509(signerConfig.CertFile)
+	if err != nil {
+		return nil, err
+	}
+	privateKey, err := security.LoadX509PrivateKey(signerConfig.KeyFile)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkCertificatePrivateKey(certificate, privateKey); err != nil {
+		return nil, err
+	}
+	if len(certificate) == 1 && isRootCA(certificate[0]) {
+		return &Signer{
+			validFrom: func() time.Time {
+				t, _ := tparse.ParseNow(time.RFC3339, signerConfig.ValidFrom)
+				return t
+			},
+			validFor:    signerConfig.ExpiresIn,
+			certificate: certificate,
+			privateKey:  privateKey,
+			ownerClaim:  ownerClaim,
+			hubID:       hubID,
+		}, nil
+	}
+
+	intermediateCA := x509.NewCertPool()
+	rootCA := x509.NewCertPool()
+	for _, caFile := range signerConfig.caPoolArray {
+		certs, err := security.LoadX509(caFile)
+		if err != nil {
+			return nil, err
+		}
+		setCAPools(rootCA, intermediateCA, certs)
+	}
+	setCAPools(rootCA, intermediateCA, certificate[1:])
+
+	verifyOpts := x509.VerifyOptions{
+		Roots:         rootCA,
+		Intermediates: intermediateCA,
+		CurrentTime:   time.Now(),
+	}
+
+	chains, err := certificate[0].Verify(verifyOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Signer{
+		validFrom: func() time.Time {
+			t, _ := tparse.ParseNow(time.RFC3339, signerConfig.ValidFrom)
+			return t
+		},
+		validFor:    signerConfig.ExpiresIn,
+		certificate: chains[0],
+		privateKey:  privateKey,
+		ownerClaim:  ownerClaim,
+		hubID:       hubID,
+	}, nil
+}
+
+func (s *Signer) Sign(ctx context.Context, csr []byte) ([]byte, *pb.SigningRecord, error) {
+	notBefore := s.validFrom()
+	notAfter := notBefore.Add(s.validFor)
+	var signingRecord *pb.SigningRecord
+	signer := certificateSigner.New(s.certificate, s.privateKey, certificateSigner.WithNotBefore(notBefore), certificateSigner.WithNotAfter(notAfter), certificateSigner.WithOverrideCertTemplate(func(template *x509.Certificate) error {
+		subject, err := overrideSubject(ctx, template.Subject, s.ownerClaim, s.hubID, "")
+		if err != nil {
+			return err
+		}
+		template.Subject = subject
+		owner, err := ownerToUUID(ctx, s.ownerClaim)
+		if err != nil {
+			return err
+		}
+		signingRecord, err = toSigningRecord(owner, template)
+		return err
+	}))
+	crt, err := signer.Sign(ctx, csr)
+	return crt, signingRecord, err
+}
+
+func (s *Signer) SignIdentityCSR(ctx context.Context, csr []byte) ([]byte, *pb.SigningRecord, error) {
+	notBefore := s.validFrom()
+	notAfter := notBefore.Add(s.validFor)
+	var signingRecord *pb.SigningRecord
+	signer := certificateSigner.NewIdentityCertificateSigner(s.certificate, s.privateKey, certificateSigner.WithNotBefore(notBefore), certificateSigner.WithNotAfter(notAfter), certificateSigner.WithOverrideCertTemplate(func(template *x509.Certificate) error {
+		subject, err := overrideSubject(ctx, template.Subject, s.ownerClaim, s.hubID, "uuid:")
+		if err != nil {
+			return err
+		}
+		template.Subject = subject
+		owner, err := ownerToUUID(ctx, s.ownerClaim)
+		if err != nil {
+			return err
+		}
+		signingRecord, err = toSigningRecord(owner, template)
+		return err
+	}))
+	cert, err := signer.Sign(ctx, csr)
+	return cert, signingRecord, err
+}

--- a/certificate-authority/service/grpc/signer_internal_test.go
+++ b/certificate-authority/service/grpc/signer_internal_test.go
@@ -1,0 +1,191 @@
+package grpc
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/plgd-dev/device/v2/pkg/security/generateCertificate"
+	"github.com/plgd-dev/kit/v2/security"
+	"github.com/stretchr/testify/require"
+)
+
+func privateKeyToPem(t *testing.T, priv *ecdsa.PrivateKey) []byte {
+	privKey, err := x509.MarshalECPrivateKey(priv)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: privKey})
+}
+
+func createCACertificate(t *testing.T) ([]byte, *ecdsa.PrivateKey) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	var cfg generateCertificate.Configuration
+	cfg.Subject.CommonName = "rootCA"
+	cfg.ValidFor = time.Hour * 24
+	cfg.BasicConstraints.MaxPathLen = 1000
+	rootCA, err := generateCertificate.GenerateRootCA(cfg, priv)
+	require.NoError(t, err)
+	return rootCA, priv
+}
+
+func createIntermediateCACertificate(t *testing.T, signerCerts []byte, signerPriv *ecdsa.PrivateKey) ([]byte, *ecdsa.PrivateKey) {
+	certs, err := security.ParseX509FromPEM(signerCerts)
+	require.NoError(t, err)
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	var cfg generateCertificate.Configuration
+	cfg.Subject.CommonName = "intermediateCA"
+	cfg.ValidFor = time.Hour * 24
+	cfg.BasicConstraints.MaxPathLen = 100
+	rootCA, err := generateCertificate.GenerateIntermediateCA(cfg, priv, certs, signerPriv)
+	require.NoError(t, err)
+	return rootCA, priv
+}
+
+func joinPems(pems ...[]byte) []byte {
+	ret := make([]byte, 0, 4096)
+	for i := range pems {
+		ret = append(ret, pems[i]...)
+	}
+	return ret
+}
+
+func certificatesToPems(certs []*x509.Certificate) []byte {
+	ret := make([]byte, 0, 4096)
+	for i := range certs {
+		ret = append(ret, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certs[i].Raw})...)
+	}
+	return ret
+}
+
+func getLeafCertificate(pem []byte) []byte {
+	certs, err := security.ParseX509FromPEM(pem)
+	if err != nil {
+		panic(err)
+	}
+	return certificatesToPems(certs[:1])
+}
+
+func TestNewSigner(t *testing.T) {
+	tmp, err := os.MkdirTemp("", "testNewSigner*****")
+	require.NoError(t, err)
+	defer func() {
+		err = os.RemoveAll(tmp)
+		require.NoError(t, err)
+	}()
+	rootCert, rootPrivKey := createCACertificate(t)
+	intermediateCert1, intermediatePrivKey1 := createIntermediateCACertificate(t, rootCert, rootPrivKey)
+	intermediateCert2, intermediatePrivKey2 := createIntermediateCACertificate(t, intermediateCert1, intermediatePrivKey1)
+
+	intermediateCert1 = getLeafCertificate(intermediateCert1)
+	intermediateCert2 = getLeafCertificate(intermediateCert2)
+
+	fullChainCrt := path.Join(tmp, "fullChain.crt")
+	rootIntermediate1Crt := path.Join(tmp, "rootIntermediate1.crt")
+	intermediate2Crt := path.Join(tmp, "intermediate2.crt")
+	intermediate2intermediate1 := path.Join(tmp, "intermediate2intermediate1.crt")
+	intermediate2Key := path.Join(tmp, "intermediate2.key")
+	rootCrt := path.Join(tmp, "root.crt")
+	rootKey := path.Join(tmp, "root.key")
+
+	err = os.WriteFile(fullChainCrt, joinPems(intermediateCert2, intermediateCert1, rootCert), 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(rootIntermediate1Crt, joinPems(intermediateCert1, rootCert), 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(intermediate2Crt, intermediateCert2, 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(intermediate2intermediate1, joinPems(intermediateCert2, intermediateCert1), 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(intermediate2Key, privateKeyToPem(t, intermediatePrivKey2), 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(rootCrt, rootCert, 0o600)
+	require.NoError(t, err)
+	err = os.WriteFile(rootKey, privateKeyToPem(t, rootPrivKey), 0o600)
+	require.NoError(t, err)
+	type args struct {
+		signerConfig SignerConfig
+	}
+	tests := []struct {
+		name             string
+		args             args
+		wantErr          bool
+		wantCertificates []byte
+	}{
+		{
+			name:    "empty",
+			wantErr: true,
+		},
+		{
+			name: "root",
+			args: args{
+				signerConfig: SignerConfig{
+					CertFile: rootCrt,
+					KeyFile:  rootKey,
+				},
+			},
+			wantCertificates: joinPems(rootCert),
+		},
+		{
+			name: "fullChain",
+			args: args{
+				signerConfig: SignerConfig{
+					CertFile: fullChainCrt,
+					KeyFile:  intermediate2Key,
+				},
+			},
+			wantCertificates: joinPems(intermediateCert2, intermediateCert1, rootCert),
+		},
+		{
+			name: "intermediate2Crt",
+			args: args{
+				signerConfig: SignerConfig{
+					caPoolArray: []string{rootIntermediate1Crt},
+					CertFile:    intermediate2Crt,
+					KeyFile:     intermediate2Key,
+				},
+			},
+			wantCertificates: joinPems(intermediateCert2, intermediateCert1, rootCert),
+		},
+		{
+			name: "intermediate2intermediate1",
+			args: args{
+				signerConfig: SignerConfig{
+					caPoolArray: []string{rootCrt},
+					CertFile:    intermediate2intermediate1,
+					KeyFile:     intermediate2Key,
+				},
+			},
+			wantCertificates: joinPems(intermediateCert2, intermediateCert1, rootCert),
+		},
+		{
+			name: "intermediate2Crt - fail",
+			args: args{
+				signerConfig: SignerConfig{
+					caPoolArray: []string{rootCrt},
+					CertFile:    intermediate2Crt,
+					KeyFile:     intermediate2Key,
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewSigner("tt.args.ownerClaim", "tt.args.hubID", tt.args.signerConfig)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotEmpty(t, got)
+			require.Equal(t, string(tt.wantCertificates), string(certificatesToPems(got.certificate)))
+		})
+	}
+}

--- a/certificate-authority/service/service.go
+++ b/certificate-authority/service/service.go
@@ -83,11 +83,12 @@ func New(ctx context.Context, config Config, fileWatcher *fsnotify.Watcher, logg
 	}
 	closerFn.AddFunc(closeStore)
 
-	ca, err := grpcService.NewCertificateAuthorityServer(config.APIs.GRPC.Authorization.OwnerClaim, config.HubID, config.Signer, dbStorage, logger)
+	ca, err := grpcService.NewCertificateAuthorityServer(config.APIs.GRPC.Authorization.OwnerClaim, config.HubID, config.Signer, dbStorage, fileWatcher, logger)
 	if err != nil {
 		closerFn.Execute()
-		return nil, fmt.Errorf("cannot create open telemetry collector client: %w", err)
+		return nil, fmt.Errorf("cannot create grpc certificate authority server: %w", err)
 	}
+	closerFn.AddFunc(ca.Close)
 	httpValidator, err := validator.New(ctx, config.APIs.GRPC.Authorization.Config, fileWatcher, logger, tracerProvider)
 	if err != nil {
 		closerFn.Execute()

--- a/certificate-authority/test/service.go
+++ b/certificate-authority/test/service.go
@@ -27,6 +27,7 @@ func MakeConfig(t require.TestingT) service.Config {
 	cfg.APIs.HTTP.Addr = config.CERTIFICATE_AUTHORITY_HTTP_HOST
 	cfg.APIs.HTTP.Server = config.MakeHttpServerConfig()
 	cfg.APIs.GRPC.TLS.ClientCertificateRequired = false
+	cfg.Signer.CAPool = []string{os.Getenv("TEST_ROOT_CA_CERT")}
 	cfg.Signer.KeyFile = os.Getenv("TEST_ROOT_CA_KEY")
 	cfg.Signer.CertFile = os.Getenv("TEST_ROOT_CA_CERT")
 	cfg.Signer.ValidFrom = "now-1h"

--- a/charts/plgd-hub/README.md
+++ b/charts/plgd-hub/README.md
@@ -54,7 +54,8 @@ global:
 |-----|------|---------|-------------|
 | certificateauthority.affinity | string | `nil` | Affinity definition |
 | certificateauthority.apis | object | `{"grpc":{"address":null,"authorization":{"audience":null,"authority":null,"http":{"idleConnTimeout":"30s","maxConnsPerHost":32,"maxIdleConns":16,"maxIdleConnsPerHost":16,"timeout":"10s","tls":{"caPool":null,"certFile":null,"keyFile":null,"useSystemCAPool":true}},"ownerClaim":null},"enforcementPolicy":{"minTime":"5s","permitWithoutStream":true},"keepAlive":{"maxConnectionAge":"0s","maxConnectionAgeGrace":"0s","maxConnectionIdle":"0s","time":"2h","timeout":"20s"},"recvMsgSize":4194304,"sendMsgSize":4194304,"tls":{"caPool":null,"certFile":null,"clientCertificateRequired":false,"keyFile":null}},"http":{"address":null,"idleTimeout":"30s","readHeaderTimeout":"4s","readTimeout":"8s","writeTimeout":"16s"}}` | For complete certificate-authority service configuration see [plgd/certificate-authority](https://github.com/plgd-dev/hub/tree/main/certificate-authority) |
-| certificateauthority.ca | object | `{"cert":"tls.crt","key":"tls.key","secret":{"name":null},"volume":{"mountPath":"/certs/coap-device-ca","name":"coap-device-ca"}}` | CA section |
+| certificateauthority.ca | object | `{"ca":null,"cert":"tls.crt","key":"tls.key","secret":{"name":null},"volume":{"mountPath":"/certs/coap-device-ca","name":"coap-device-ca"}}` | CA section |
+| certificateauthority.ca.ca | string | `nil` | CA file name in case of external CA |
 | certificateauthority.ca.cert | string | `"tls.crt"` | Cert file name |
 | certificateauthority.ca.key | string | `"tls.key"` | Cert key file name |
 | certificateauthority.ca.secret.name | string | `nil` | Name of secret |
@@ -140,7 +141,7 @@ global:
 | certificateauthority.service.http.protocol | string | `"TCP"` | Protocol |
 | certificateauthority.service.http.targetPort | string | `"http"` | Target port |
 | certificateauthority.service.http.type | string | `"ClusterIP"` | Service type |
-| certificateauthority.signer | object | `{"certFile":null,"expiresIn":"87600h","keyFile":null,"validFrom":"now-1h"}` | For complete certificate-authority service configuration see [plgd/certificate-authority](https://github.com/plgd-dev/hub/tree/main/certificate-authority) |
+| certificateauthority.signer | object | `{"caPool":null,"certFile":null,"expiresIn":"87600h","keyFile":null,"validFrom":"now-1h"}` | For complete certificate-authority service configuration see [plgd/certificate-authority](https://github.com/plgd-dev/hub/tree/main/certificate-authority) |
 | certificateauthority.tolerations | string | `nil` | Toleration definition |
 | certmanager | object | `{"coap":{"cert":{"duration":null,"key":{"algorithm":null,"size":null},"renewBefore":null},"issuer":{"annotations":{},"kind":null,"labels":{},"name":null,"spec":null}},"default":{"ca":{"commonName":"plgd-ca","enabled":true,"issuer":{"annotations":{},"enabled":true,"kind":"Issuer","labels":{},"name":"ca-issuer","spec":{"selfSigned":{}}},"secret":{"name":"plgd-ca"}},"cert":{"annotations":{},"duration":"8760h0m0s","key":{"algorithm":"ECDSA","size":256},"labels":{},"renewBefore":"360h0m0s"},"issuer":{"annotations":{},"enabled":true,"kind":"Issuer","labels":{},"name":"default-issuer","spec":{"selfSigned":{}}}},"enabled":true,"external":{"cert":{"duration":null,"key":{"algorithm":null,"size":null},"renewBefore":null},"issuer":{"annotations":{},"kind":null,"labels":{},"name":null,"spec":null}},"internal":{"cert":{"duration":null,"key":{"algorithm":null,"size":null},"renewBefore":null},"issuer":{"annotations":{},"kind":null,"labels":{},"name":null,"spec":null}}}` | Cert-manager integration section |
 | certmanager.coap.cert.duration | string | `nil` | Certificate duration |

--- a/charts/plgd-hub/templates/certificate-authority/config.yaml
+++ b/charts/plgd-hub/templates/certificate-authority/config.yaml
@@ -76,6 +76,11 @@ data:
             documentLimit: {{ .clients.storage.mongoDB.bulkWrite.documentLimit  }}
       {{- include "plgd-hub.openTelemetryExporterConfig" (list $ $cert ) | nindent 6 }}
     signer:
+    {{- if .signer.caPool }}
+      caPool: {{ .signer.caPool | quote }}
+    {{- else if $.Values.certificateauthority.ca.ca }}
+      caPool: {{ printf "%s/%s" $.Values.certificateauthority.ca.volume.mountPath $.Values.certificateauthority.ca.ca | quote }}
+    {{- end }}
       certFile: {{ .signer.certFile | default ( printf "%s/%s" $.Values.certificateauthority.ca.volume.mountPath $.Values.certificateauthority.ca.cert ) | quote }}
       keyFile: {{ .signer.keyFile | default ( printf "%s/%s" $.Values.certificateauthority.ca.volume.mountPath $.Values.certificateauthority.ca.key ) | quote }}
       validFrom: {{ .signer.validFrom | quote }}

--- a/charts/plgd-hub/values.yaml
+++ b/charts/plgd-hub/values.yaml
@@ -1776,6 +1776,8 @@ certificateauthority:
     cert: tls.crt
     # -- Cert key file name
     key: tls.key
+    # -- CA file name in case of external CA
+    ca:
     volume:
       # -- CA certificate volume name
       name: coap-device-ca
@@ -1869,6 +1871,7 @@ certificateauthority:
           documentLimit: 1000
   # -- For complete certificate-authority service configuration see [plgd/certificate-authority](https://github.com/plgd-dev/hub/tree/main/certificate-authority)
   signer:
+    caPool:
     keyFile:
     certFile:
     validFrom: "now-1h"

--- a/pkg/security/certManager/general/certManager.go
+++ b/pkg/security/certManager/general/certManager.go
@@ -90,8 +90,9 @@ func New(config Config, fileWatcher *fsnotify.Watcher, logger log.Logger) (*Cert
 			removeFilesOnError.Execute()
 			return nil, fmt.Errorf("cannot watch CAPool(%v): %w", ca, err)
 		}
+		caToRemove := ca
 		removeFilesOnError.AddFunc(func() {
-			_ = c.fileWatcher.Remove(ca)
+			_ = c.fileWatcher.Remove(caToRemove)
 		})
 	}
 	if config.CertFile != "" {


### PR DESCRIPTION
The Certificate Authority (`signer.certFile`) expects a complete chain of certificates, starting from the intermediate sign cert up to the root cert. However, in Kubernetes (k8s), the root cert is not included in the `tls.crt` file; it is stored separately as `ca.crt`. Therefore, this commit allows you to specify the CA file as well via the `signer.caPool`. This change enables the resolution of the full certificate chain, which is used during certificate signing.