### PR TITLE
resource-aggregate: services expiration monitoring

### DIFF
--- a/grpc-gateway/service/subscribeToEvents_test.go
+++ b/grpc-gateway/service/subscribeToEvents_test.go
@@ -992,7 +992,7 @@ func TestCoAPGatewayServiceHeartbeat(t *testing.T) {
 	raTearDown := raTest.New(t, racfg)
 
 	coapgwCfg := coapgwTest.MakeConfig(t)
-	coapgwCfg.ServiceHeartbeat.TimeToLive = time.Second * 2
+	coapgwCfg.ServiceHeartbeat.TimeToLive = time.Second * 3
 	coapgwTearDown := coapgwTest.New(t, coapgwCfg)
 
 	ctx = kitNetGrpc.CtxWithToken(ctx, oauthTest.GetDefaultAccessToken(t))
@@ -1086,7 +1086,7 @@ func TestCoAPGatewayServiceHeartbeat(t *testing.T) {
 	require.NotEmpty(t, secondCoapGWInstanceID)
 	require.NotEqual(t, firstCoapGWInstanceID, secondCoapGWInstanceID)
 
-	// set device to offline by resource-aggregate without restart the coap-gw
+	// ---- Set the device to offline via the resource-aggregate without updating the service metadata through the CoAP gateway. ---
 	// turn off resource-aggregate
 	raTearDown()
 	coapgwTearDown()

--- a/pkg/security/oauth2/token.go
+++ b/pkg/security/oauth2/token.go
@@ -40,7 +40,7 @@ func (o Token) Refresh(ctx context.Context, cfg oauth2.Config) (Token, bool, err
 }
 
 func (o Token) IsValidAccessToken() bool {
-	if o.Expiry.IsZero() || o.Expiry.UnixNano() > time.Now().UnixNano() {
+	if o.Expiry.IsZero() || o.Expiry.After(time.Now()) {
 		return true
 	}
 	return false

--- a/resource-aggregate/service/updateServiceHeartbeat.go
+++ b/resource-aggregate/service/updateServiceHeartbeat.go
@@ -309,8 +309,8 @@ func (s *ServiceHeartbeat) run() {
 		}
 		nextWakeUp := s.processRequests()
 		d := time.Until(nextWakeUp)
-		if d < 0 {
-			d = time.Hour
+		if d <= 0 {
+			d = time.Minute * 10
 		}
 		// stop timer and drain if it was not already expired
 		if !timer.Stop() {

--- a/test/iotivity-lite/service/offboard_test.go
+++ b/test/iotivity-lite/service/offboard_test.go
@@ -361,6 +361,9 @@ func TestOffboardWithSignInByRefreshToken(t *testing.T) {
 	deviceID, _ = test.OnboardDevSim(ctx, t, c, deviceID, string(schema.TCPSecureScheme)+"://"+config.COAP_GW_HOST, nil)
 	require.True(t, sh.WaitForFirstSignIn(time.Second*20))
 
+	// sleep to get response to the device
+	time.Sleep(time.Second)
+
 	// first retry after failure is after 2 seconds, so hopefully it doesn't trigger, if this test
 	// behaves flakily then we will have to update simulator to have a configurable retry
 	sh.failSignIn.Store(false)
@@ -414,6 +417,8 @@ func TestOffboardWithRepeat(t *testing.T) {
 	// deviceID, _ = test.OnboardDevSim(ctx, t, c, deviceID, config.ACTIVE_COAP_SCHEME+"://"+config.COAP_GW_HOST, nil)
 	deviceID, _ = test.OnboardDevSim(ctx, t, c, deviceID, string(schema.TCPSecureScheme)+"://"+config.COAP_GW_HOST, nil)
 	require.True(t, sh.WaitForFirstSignIn(time.Second*20))
+
+	time.Sleep(time.Second)
 
 	test.OffBoardDevSim(ctx, t, deviceID)
 	test.OffBoardDevSim(ctx, t, deviceID)
@@ -473,6 +478,8 @@ func TestOffboardInterrupt(t *testing.T) {
 	// deviceID, _ = test.OnboardDevSim(ctx, t, c, deviceID, config.ACTIVE_COAP_SCHEME+"://"+config.COAP_GW_HOST, nil)
 	deviceID, _ = test.OnboardDevSim(ctx, t, c, deviceID, string(schema.TCPSecureScheme)+"://"+config.COAP_GW_HOST, nil)
 	require.True(t, sh.WaitForFirstSignIn(time.Second*20))
+
+	time.Sleep(time.Second)
 
 	test.OffBoardDevSim(ctx, t, deviceID)
 	require.True(t, sh.WaitForFirstRefreshToken(time.Second*20))


### PR DESCRIPTION
Enables the capability to transition devices into an offline state if necessary, independently of the origin service.