### PR TITLE
coap-gateway: Avoid Duplicate Observations

### DIFF
--- a/coap-gateway/service/resourceDirectory.go
+++ b/coap-gateway/service/resourceDirectory.go
@@ -140,9 +140,13 @@ func observeResources(ctx context.Context, client *session, w wkRd, sequenceNumb
 		publishedResources: publishedResources,
 	}
 	if err := client.server.taskQueue.Submit(func() {
-		obs, errObs := x.client.getDeviceObserver(x.ctx)
+		obs, ok, errObs := x.client.getDeviceObserver(x.ctx)
 		if errObs != nil {
 			x.client.Errorf("%w", x.observeError(x.w.DeviceID, errObs))
+			return
+		}
+		if !ok {
+			x.client.Errorf("%w", x.observeError(x.w.DeviceID, fmt.Errorf("cannot get device observer")))
 			return
 		}
 		if errObs := obs.AddPublishedResources(x.ctx, x.publishedResources); errObs != nil {

--- a/coap-gateway/service/session.go
+++ b/coap-gateway/service/session.go
@@ -348,8 +348,8 @@ func (c *session) onGetResourceContent(ctx context.Context, deviceID, href strin
 			x.c.Errorf("%w", x.cannotGetResourceContentError(x.deviceID, x.href, err2))
 			return
 		}
-		obs, err2 := x.c.getDeviceObserver(x.c.Context())
-		if err2 == nil {
+		obs, ok, _ := x.c.getDeviceObserver(x.c.Context())
+		if ok {
 			obs.ResourceHasBeenSynchronized(x.ctx, x.href)
 		}
 	})
@@ -403,8 +403,8 @@ func (c *session) onObserveResource(ctx context.Context, deviceID, href string, 
 			x.c.Errorf("%w", x.cannotObserResourceError(err2))
 			return
 		}
-		obs, err2 := x.c.getDeviceObserver(x.c.Context())
-		if err2 == nil {
+		obs, ok, _ := x.c.getDeviceObserver(x.c.Context())
+		if ok {
 			obs.ResourceHasBeenSynchronized(x.ctx, x.href)
 		}
 	})
@@ -820,9 +820,13 @@ func (c *session) unpublishResourceLinks(ctx context.Context, hrefs []string, in
 		return nil
 	}
 
-	observer, err := c.getDeviceObserver(ctx)
+	observer, ok, err := c.getDeviceObserver(ctx)
 	if err != nil {
 		logUnpublishError(err)
+		return resp.UnpublishedHrefs
+	}
+	if !ok {
+		logUnpublishError(fmt.Errorf("device observer not found"))
 		return resp.UnpublishedHrefs
 	}
 	observer.RemovePublishedResources(ctx, resp.UnpublishedHrefs)


### PR DESCRIPTION
When the device refreshes its token and performs a sign-in operation, the CoAP gateway checks if the observation has already been created. If it has, it is left unchanged.