### PR TITLE
Web: Pagination Regression and Theme Generation Simplification

### DIFF
--- a/http-gateway/web/src/containers/App/AppLayout/AppLayout.tsx
+++ b/http-gateway/web/src/containers/App/AppLayout/AppLayout.tsx
@@ -19,6 +19,7 @@ import { flushDevices } from '@shared-ui/app/clientApp/Devices/slice'
 import { reset } from '@shared-ui/app/clientApp/App/AppRest'
 import { ToastContainer } from '@shared-ui/components/Atomic'
 import { ThemeType } from '@shared-ui/components/Atomic/_theme'
+import { clientAppSettings } from '@shared-ui/common/services'
 
 import { Props } from './AppLayout.types'
 import { mather, menu, Routes } from '@/routes'
@@ -128,6 +129,9 @@ const AppLayout: FC<Props> = (props) => {
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [signOutRedirect])
+
+    // reset
+    clientAppSettings.setUseToken(true)
 
     return (
         <>

--- a/http-gateway/web/src/containers/Configuration/ConfigurationPage.i18n.ts
+++ b/http-gateway/web/src/containers/Configuration/ConfigurationPage.i18n.ts
@@ -1,32 +1,36 @@
 import { defineMessages } from '@formatjs/intl'
 
 export const messages = defineMessages({
+    configurationPage: {
+        id: 'configurationPage.configurationPage',
+        defaultMessage: 'Configuration Page',
+    },
     configurationUpdated: {
-        id: 'devices.configurationUpdated',
+        id: 'configurationPage.configurationUpdated',
         defaultMessage: 'Configuration Updated',
     },
     configurationUpdatedMessage: {
-        id: 'devices.configurationUpdatedMessage',
+        id: 'configurationPage.configurationUpdatedMessage',
         defaultMessage: 'The configuration was successfully updated.',
     },
     reset: {
-        id: 'remoteClients.reset',
+        id: 'configurationPage.reset',
         defaultMessage: 'Reset',
     },
     saveChanges: {
-        id: 'remoteClients.saveChanges',
+        id: 'configurationPage.saveChanges',
         defaultMessage: 'Save changes',
     },
     changesMade: {
-        id: 'remoteClients.changesMade',
+        id: 'configurationPage.changesMade',
         defaultMessage: 'Changes made',
     },
     setting: {
-        id: 'remoteClients.setting',
+        id: 'configurationPage.setting',
         defaultMessage: 'setting',
     },
     settings: {
-        id: 'remoteClients.settings',
+        id: 'configurationPage.settings',
         defaultMessage: 'settings',
     },
 })

--- a/http-gateway/web/src/containers/Configuration/ConfigurationPage.tsx
+++ b/http-gateway/web/src/containers/Configuration/ConfigurationPage.tsx
@@ -16,7 +16,7 @@ import { useIsMounted } from '@shared-ui/common/hooks'
 
 import { Inputs } from './ConfigurationPage.types'
 import notificationId from '@/notificationId'
-import { messages as t } from './Configuration.i18n'
+import { messages as t } from './ConfigurationPage.i18n'
 import { CombinedStoreType } from '@/store/store'
 import { setTheme } from '@/containers/App/slice'
 
@@ -86,7 +86,7 @@ const ConfigurationPage = () => {
     return (
         <PageLayout
             footer={<Footer paginationComponent={<div id='paginationPortalTarget'></div>} recentTasksPortal={<div id='recentTasksPortalTarget'></div>} />}
-            title='App Configuration'
+            title={_(t.configurationPage)}
         >
             <form onSubmit={handleSubmit(onSubmit)}>
                 <SimpleStripTable rows={rows} />

--- a/http-gateway/web/src/containers/Devices/List/DevicesListPage/DevicesListPage.tsx
+++ b/http-gateway/web/src/containers/Devices/List/DevicesListPage/DevicesListPage.tsx
@@ -280,6 +280,7 @@ const DevicesListPage: FC<any> = () => {
                     search: _(g.search),
                     select: _(g.select),
                 }}
+                isActiveTab={true}
                 isAllSelected={isAllSelected}
                 loading={loadingOrDeleting}
                 onDeleteClick={handleOpenDeleteModal}


### PR DESCRIPTION
### 1. Pagination Restoration at Devices Site

This PR addresses a regression introduced in the latest web update, which led to the loss of pagination functionality on the devices site. The changes implemented here restore the pagination feature, ensuring a smooth user experience.

### 2. Theme Generation Fix

Additionally, this PR resolves an issue related to theme generation. The fix involves simplifying the process, requiring only the execution of the `npm` command. This adjustment streamlines the theme generation workflow for improved efficiency.

### 3. 'Types' column display issue on DevicesList page

This pull request addresses an issue where the 'Types' column on the DevicesList page was not displaying correctly.

### 4. Token reset issue connected with remote client pages

The last thing that pull request addresses is an issue related to token reset in the remote client. The problem was identified as a missing token in request after visiting remote client's pages configured as PRE_SHARED_KEY.
