### PR TITLE
Charts: Propagate Group Attribute to issuerRef for Certificate

### DIFF
--- a/charts/plgd-hub/README.md
+++ b/charts/plgd-hub/README.md
@@ -143,24 +143,27 @@ global:
 | certificateauthority.service.http.type | string | `"ClusterIP"` | Service type |
 | certificateauthority.signer | object | `{"caPool":null,"certFile":null,"expiresIn":"87600h","keyFile":null,"validFrom":"now-1h"}` | For complete certificate-authority service configuration see [plgd/certificate-authority](https://github.com/plgd-dev/hub/tree/main/certificate-authority) |
 | certificateauthority.tolerations | string | `nil` | Toleration definition |
-| certmanager | object | `{"coap":{"cert":{"duration":null,"key":{"algorithm":null,"size":null},"renewBefore":null},"issuer":{"annotations":{},"kind":null,"labels":{},"name":null,"spec":null}},"default":{"ca":{"commonName":"plgd-ca","enabled":true,"issuer":{"annotations":{},"enabled":true,"kind":"Issuer","labels":{},"name":"ca-issuer","spec":{"selfSigned":{}}},"issuerRef":{"kind":null,"name":null},"secret":{"name":"plgd-ca"}},"cert":{"annotations":{},"duration":"8760h0m0s","key":{"algorithm":"ECDSA","size":256},"labels":{},"renewBefore":"360h0m0s"},"issuer":{"annotations":{},"enabled":true,"kind":"Issuer","labels":{},"name":"default-issuer","spec":{"selfSigned":{}}}},"enabled":true,"external":{"cert":{"duration":null,"key":{"algorithm":null,"size":null},"renewBefore":null},"issuer":{"annotations":{},"kind":null,"labels":{},"name":null,"spec":null}},"internal":{"cert":{"duration":null,"key":{"algorithm":null,"size":null},"renewBefore":null},"issuer":{"annotations":{},"kind":null,"labels":{},"name":null,"spec":null}}}` | Cert-manager integration section |
+| certmanager | object | `{"coap":{"cert":{"duration":null,"key":{"algorithm":null,"size":null},"renewBefore":null},"issuer":{"annotations":{},"group":null,"kind":null,"labels":{},"name":null,"spec":null}},"default":{"ca":{"commonName":"plgd-ca","enabled":true,"issuer":{"annotations":{},"enabled":true,"group":null,"kind":"Issuer","labels":{},"name":"ca-issuer","spec":{"selfSigned":{}}},"issuerRef":{"group":null,"kind":null,"name":null},"secret":{"name":"plgd-ca"}},"cert":{"annotations":{},"duration":"8760h0m0s","key":{"algorithm":"ECDSA","size":256},"labels":{},"renewBefore":"360h0m0s"},"issuer":{"annotations":{},"enabled":true,"group":"cert-manager.io","kind":"Issuer","labels":{},"name":"default-issuer","spec":{"selfSigned":{}}}},"enabled":true,"external":{"cert":{"duration":null,"key":{"algorithm":null,"size":null},"renewBefore":null},"issuer":{"annotations":{},"group":null,"kind":null,"labels":{},"name":null,"spec":null}},"internal":{"cert":{"duration":null,"key":{"algorithm":null,"size":null},"renewBefore":null},"issuer":{"annotations":{},"group":null,"kind":null,"labels":{},"name":null,"spec":null}}}` | Cert-manager integration section |
 | certmanager.coap.cert.duration | string | `nil` | Certificate duration |
 | certmanager.coap.cert.key.algorithm | string | `nil` | Certificate key algorithm |
 | certmanager.coap.cert.key.size | string | `nil` | Certificate key size |
 | certmanager.coap.cert.renewBefore | string | `nil` | Certificate renew before |
 | certmanager.coap.issuer.annotations | object | `{}` | Annotations |
+| certmanager.coap.issuer.group | string | `nil` | Group of coap issuer |
 | certmanager.coap.issuer.kind | string | `nil` | Kind of coap issuer |
 | certmanager.coap.issuer.labels | object | `{}` | Labels |
 | certmanager.coap.issuer.name | string | `nil` | Name |
 | certmanager.coap.issuer.spec | string | `nil` | cert-manager issuer spec |
-| certmanager.default | object | `{"ca":{"commonName":"plgd-ca","enabled":true,"issuer":{"annotations":{},"enabled":true,"kind":"Issuer","labels":{},"name":"ca-issuer","spec":{"selfSigned":{}}},"issuerRef":{"kind":null,"name":null},"secret":{"name":"plgd-ca"}},"cert":{"annotations":{},"duration":"8760h0m0s","key":{"algorithm":"ECDSA","size":256},"labels":{},"renewBefore":"360h0m0s"},"issuer":{"annotations":{},"enabled":true,"kind":"Issuer","labels":{},"name":"default-issuer","spec":{"selfSigned":{}}}}` | Default cert-manager section |
+| certmanager.default | object | `{"ca":{"commonName":"plgd-ca","enabled":true,"issuer":{"annotations":{},"enabled":true,"group":null,"kind":"Issuer","labels":{},"name":"ca-issuer","spec":{"selfSigned":{}}},"issuerRef":{"group":null,"kind":null,"name":null},"secret":{"name":"plgd-ca"}},"cert":{"annotations":{},"duration":"8760h0m0s","key":{"algorithm":"ECDSA","size":256},"labels":{},"renewBefore":"360h0m0s"},"issuer":{"annotations":{},"enabled":true,"group":"cert-manager.io","kind":"Issuer","labels":{},"name":"default-issuer","spec":{"selfSigned":{}}}}` | Default cert-manager section |
 | certmanager.default.ca.commonName | string | `"plgd-ca"` | Common name for CA created as default issuer |
 | certmanager.default.ca.issuer.annotations | object | `{}` | Annotation for root issuer |
 | certmanager.default.ca.issuer.enabled | bool | `true` | Enable root issuer |
-| certmanager.default.ca.issuer.kind | string | `"Issuer"` | Kind of default issuer |
+| certmanager.default.ca.issuer.group | string | `nil` | Group of root issuer |
+| certmanager.default.ca.issuer.kind | string | `"Issuer"` | Kind of root issuer |
 | certmanager.default.ca.issuer.labels | object | `{}` | Labels for root issuer |
 | certmanager.default.ca.issuer.name | string | `"ca-issuer"` | Name of root issuer |
 | certmanager.default.ca.issuer.spec | object | `{"selfSigned":{}}` | Default issuer specification. |
+| certmanager.default.ca.issuerRef.group | string | `nil` | Group of issuer for sign CA |
 | certmanager.default.ca.issuerRef.kind | string | `nil` | Kind of CA issuer |
 | certmanager.default.ca.issuerRef.name | string | `nil` | Name of issuer for sign CA |
 | certmanager.default.ca.secret.name | string | `"plgd-ca"` | Name of secret |
@@ -172,9 +175,10 @@ global:
 | certmanager.default.cert.key.size | int | `256` | Key size |
 | certmanager.default.cert.labels | object | `{}` | Certificate labels |
 | certmanager.default.cert.renewBefore | string | `"360h0m0s"` | Certificate renew before |
-| certmanager.default.issuer | object | `{"annotations":{},"enabled":true,"kind":"Issuer","labels":{},"name":"default-issuer","spec":{"selfSigned":{}}}` | Default cert-manager issuer |
+| certmanager.default.issuer | object | `{"annotations":{},"enabled":true,"group":"cert-manager.io","kind":"Issuer","labels":{},"name":"default-issuer","spec":{"selfSigned":{}}}` | Default cert-manager issuer |
 | certmanager.default.issuer.annotations | object | `{}` | Annotation for default issuer |
 | certmanager.default.issuer.enabled | bool | `true` | Enable Default issuer |
+| certmanager.default.issuer.group | string | `"cert-manager.io"` | Group of default issuer |
 | certmanager.default.issuer.kind | string | `"Issuer"` | Kind of default issuer |
 | certmanager.default.issuer.labels | object | `{}` | Labels for default issuer |
 | certmanager.default.issuer.name | string | `"default-issuer"` | Name of default issuer |
@@ -185,6 +189,7 @@ global:
 | certmanager.external.cert.key.size | string | `nil` | Certificate key size |
 | certmanager.external.cert.renewBefore | string | `nil` | Certificate renew before |
 | certmanager.external.issuer.annotations | object | `{}` | Annotations |
+| certmanager.external.issuer.group | string | `nil` | Group of external issuer |
 | certmanager.external.issuer.kind | string | `nil` | Kind of external issuer |
 | certmanager.external.issuer.labels | object | `{}` | Labels |
 | certmanager.external.issuer.name | string | `nil` | Name |
@@ -193,8 +198,9 @@ global:
 | certmanager.internal.cert.key.algorithm | string | `nil` | Certificate key algorithm |
 | certmanager.internal.cert.key.size | string | `nil` | Certificate key size |
 | certmanager.internal.cert.renewBefore | string | `nil` | Certificate renew before |
-| certmanager.internal.issuer | object | `{"annotations":{},"kind":null,"labels":{},"name":null,"spec":null}` | Internal issuer. In case you want to create your own issuer for internal certs |
+| certmanager.internal.issuer | object | `{"annotations":{},"group":null,"kind":null,"labels":{},"name":null,"spec":null}` | Internal issuer. In case you want to create your own issuer for internal certs |
 | certmanager.internal.issuer.annotations | object | `{}` | Annotations |
+| certmanager.internal.issuer.group | string | `nil` | Group of internal issuer |
 | certmanager.internal.issuer.kind | string | `nil` | Kind of internal issuer |
 | certmanager.internal.issuer.labels | object | `{}` | Labels |
 | certmanager.internal.issuer.name | string | `nil` | Name |

--- a/charts/plgd-hub/templates/certificate-authority/domain-crt.yaml
+++ b/charts/plgd-hub/templates/certificate-authority/domain-crt.yaml
@@ -30,5 +30,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.external.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.external.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.external.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/certificate-authority/service-crt.yaml
+++ b/charts/plgd-hub/templates/certificate-authority/service-crt.yaml
@@ -40,5 +40,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.internal.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.internal.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.internal.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/certs/default/root-ca.yaml
+++ b/charts/plgd-hub/templates/certs/default/root-ca.yaml
@@ -19,5 +19,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.default.ca.issuerRef.name | default .Values.certmanager.default.ca.issuer.name }}
     kind: {{ .Values.certmanager.default.ca.issuerRef.kind | default .Values.certmanager.default.ca.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.default.ca.issuerRef.group | default .Values.certmanager.default.ca.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/certs/internal/mongodb-crt.yaml
+++ b/charts/plgd-hub/templates/certs/internal/mongodb-crt.yaml
@@ -25,5 +25,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.internal.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.internal.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.internal.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/certs/internal/nats-crt.yaml
+++ b/charts/plgd-hub/templates/certs/internal/nats-crt.yaml
@@ -27,5 +27,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.internal.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.internal.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.internal.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/certs/wildcard-crt.yaml
+++ b/charts/plgd-hub/templates/certs/wildcard-crt.yaml
@@ -32,5 +32,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.external.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.external.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.external.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/coap-gateway/service-crt.yaml
+++ b/charts/plgd-hub/templates/coap-gateway/service-crt.yaml
@@ -32,5 +32,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.coap.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.coap.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.coap.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/grpc-gateway/domain-crt.yaml
+++ b/charts/plgd-hub/templates/grpc-gateway/domain-crt.yaml
@@ -29,5 +29,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.external.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.external.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.external.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/grpc-gateway/service-crt.yaml
+++ b/charts/plgd-hub/templates/grpc-gateway/service-crt.yaml
@@ -35,5 +35,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.internal.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.internal.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.internal.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/http-gateway/api-domain-crt.yaml
+++ b/charts/plgd-hub/templates/http-gateway/api-domain-crt.yaml
@@ -29,5 +29,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.external.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.external.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.external.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/http-gateway/service-crt.yaml
+++ b/charts/plgd-hub/templates/http-gateway/service-crt.yaml
@@ -35,5 +35,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.internal.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.internal.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.internal.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/http-gateway/ui-domain-crt.yaml
+++ b/charts/plgd-hub/templates/http-gateway/ui-domain-crt.yaml
@@ -29,5 +29,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.external.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.external.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.external.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/identity-store/service-crt.yaml
+++ b/charts/plgd-hub/templates/identity-store/service-crt.yaml
@@ -34,5 +34,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.internal.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.internal.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.internal.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/mock-oauth-server/domain-crt.yaml
+++ b/charts/plgd-hub/templates/mock-oauth-server/domain-crt.yaml
@@ -29,5 +29,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.external.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.external.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.external.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/mock-oauth-server/service-crt.yaml
+++ b/charts/plgd-hub/templates/mock-oauth-server/service-crt.yaml
@@ -35,5 +35,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.internal.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.internal.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.internal.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/resource-aggregate/service-crt.yaml
+++ b/charts/plgd-hub/templates/resource-aggregate/service-crt.yaml
@@ -35,5 +35,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.internal.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.internal.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.internal.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/templates/resource-directory/service-crt.yaml
+++ b/charts/plgd-hub/templates/resource-directory/service-crt.yaml
@@ -35,5 +35,5 @@ spec:
   issuerRef:
     name: {{ .Values.certmanager.internal.issuer.name | default .Values.certmanager.default.issuer.name }}
     kind: {{ .Values.certmanager.internal.issuer.kind | default .Values.certmanager.default.issuer.kind }}
-    group: cert-manager.io
+    group: {{ .Values.certmanager.internal.issuer.group | default .Values.certmanager.default.issuer.group }}
 {{- end }}

--- a/charts/plgd-hub/values.yaml
+++ b/charts/plgd-hub/values.yaml
@@ -223,6 +223,8 @@ certmanager:
       name: default-issuer
       # -- Kind of default issuer
       kind: Issuer
+      # -- Group of default issuer
+      group: cert-manager.io
       # -- Default issuer specification.
       spec:
         selfSigned: {}
@@ -254,6 +256,8 @@ certmanager:
         kind:
         # -- Name of issuer for sign CA
         name:
+        # -- Group of issuer for sign CA
+        group:
       issuer:
         # -- Enable root issuer
         enabled: true
@@ -263,8 +267,10 @@ certmanager:
         annotations: {}
         # -- Name of root issuer
         name: ca-issuer
-        # -- Kind of default issuer
+        # -- Kind of root issuer
         kind: Issuer
+        # -- Group of root issuer
+        group:
         # -- Default issuer specification.
         spec:
           selfSigned: {}
@@ -279,6 +285,8 @@ certmanager:
       name:
       # -- Kind of internal issuer
       kind:
+      # -- Group of internal issuer
+      group:
       # -- cert-manager issuer spec
       spec:
     cert:
@@ -301,6 +309,8 @@ certmanager:
       name:
       # -- Kind of coap issuer
       kind:
+      # -- Group of coap issuer
+      group:
       # -- cert-manager issuer spec
       spec:
     cert:
@@ -323,6 +333,8 @@ certmanager:
       name:
       # -- Kind of external issuer
       kind:
+      # -- Group of external issuer
+      group:
       # -- cert-manager issuer spec
       spec:
     cert:


### PR DESCRIPTION
This commit modifies the Certificate resource to include the `group` attribute in the `issuerRef` field. The changes ensure that the `issuerRef` accurately reflects the grouping information, improving clarity and alignment within our infrastructure.