### PR TITLE
http-gateway/ui: Delete DEVICE_AUTH_CODE_SESSION_KEY in ProvisionNewDevice modal

### DIFF
--- a/http-gateway/web/src/containers/DeviceProvisioning/LinkedHubs/DetailPage/LinkedHubsDetail.tsx
+++ b/http-gateway/web/src/containers/DeviceProvisioning/LinkedHubs/DetailPage/LinkedHubsDetail.tsx
@@ -20,7 +20,7 @@ import { updateLinkedHubData } from '@/containers/DeviceProvisioning/rest'
 import PageLayout from '@/containers/Common/PageLayout'
 import DetailHeader from '@/containers/DeviceProvisioning/LinkedHubs/DetailHeader'
 import isEqual from 'lodash/isEqual'
-import { FormContext } from '@shared-ui/common/context/FormContext'
+import { FormContext, getFormContextDefault } from '@shared-ui/common/context/FormContext'
 
 const Tab1 = lazy(() => import('./Tabs/Tab1/Tab1'))
 const Tab2 = lazy(() => import('./Tabs/Tab2/Tab2'))
@@ -110,8 +110,8 @@ const LinkedHubsDetail: FC<any> = (props) => {
 
     const context = useMemo(
         () => ({
-            onSubmit: onSubmitForm,
-            updateData: (field: string, d: any) => console.log(field, d),
+            ...getFormContextDefault('default'),
+            updateData: (data: any) => console.log(data),
         }),
         []
     )

--- a/http-gateway/web/src/containers/DeviceProvisioning/LinkedHubs/DetailPage/Tabs/Tab1/Tab1.tsx
+++ b/http-gateway/web/src/containers/DeviceProvisioning/LinkedHubs/DetailPage/Tabs/Tab1/Tab1.tsx
@@ -23,10 +23,10 @@ const Tab1: FC<Props> = (props) => {
         handleSubmit,
     } = useForm<Inputs>({ mode: 'all', reValidateMode: 'onSubmit', values: defaultFormData })
 
-    const { onSubmit } = useContext(FormContext)
+    // const { onSubmit } = useContext(FormContext)
 
     return (
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form>
             <SimpleStripTable
                 rows={[
                     {

--- a/http-gateway/web/src/containers/DeviceProvisioning/LinkedHubs/DetailPage/Tabs/Tab2/Contents/TabContent1.tsx
+++ b/http-gateway/web/src/containers/DeviceProvisioning/LinkedHubs/DetailPage/Tabs/Tab2/Contents/TabContent1.tsx
@@ -21,7 +21,7 @@ const TabContent1: FC<Props> = (props) => {
     const { defaultFormData, loading } = props
     const { formatMessage: _ } = useIntl()
 
-    const { onSubmit } = useContext(FormContext)
+    // const { onSubmit } = useContext(FormContext)
 
     const {
         formState: { errors, isDirty, touchedFields, dirtyFields, defaultValues },

--- a/http-gateway/web/src/containers/DeviceProvisioning/LinkedHubs/DetailPage/Tabs/Tab2/Contents/TabContent2.tsx
+++ b/http-gateway/web/src/containers/DeviceProvisioning/LinkedHubs/DetailPage/Tabs/Tab2/Contents/TabContent2.tsx
@@ -34,7 +34,7 @@ const TabContent2: FC<Props> = (props) => {
         control,
     } = useForm<Inputs>({ mode: 'all', reValidateMode: 'onSubmit', values: defaultFormData })
 
-    const { onSubmit } = useContext(FormContext)
+    // const { onSubmit } = useContext(FormContext)
 
     const defaultModalData = useMemo(
         () => ({
@@ -77,7 +77,7 @@ const TabContent2: FC<Props> = (props) => {
     }, [caPool, defaultModalData, modalData.value, setValue])
 
     return (
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form>
             <Headline type='h5'>{_(g.tls)}</Headline>
             <p>Short description...</p>
             <hr css={styles.separator} />

--- a/http-gateway/web/src/containers/Devices/List/ProvisionNewDevice/ProvisionNewDevice.tsx
+++ b/http-gateway/web/src/containers/Devices/List/ProvisionNewDevice/ProvisionNewDevice.tsx
@@ -10,7 +10,9 @@ import { getApiErrorMessage } from '@shared-ui/common/utils'
 
 import { getDeviceAuthCode } from '@/containers/Devices/rest'
 import { messages as t } from '@/containers/Devices/Devices.i18n'
+import { messages as g } from '@/containers/Global.i18n'
 import notificationId from '@/notificationId'
+import { DEVICE_AUTH_CODE_SESSION_KEY } from '@/constants'
 
 const ProvisionNewDeviceCore = () => {
     const [show, setShow] = useState(false)
@@ -44,12 +46,14 @@ const ProvisionNewDeviceCore = () => {
 
     const openModal = () => {
         setShow(true)
+        sessionStorage.removeItem(DEVICE_AUTH_CODE_SESSION_KEY)
         inputRef?.current?.focus()
     }
 
     const onClose = () => {
         setShow(false)
         setCode(undefined)
+        sessionStorage.removeItem(DEVICE_AUTH_CODE_SESSION_KEY)
         setDeviceId(null)
     }
 
@@ -62,7 +66,7 @@ const ProvisionNewDeviceCore = () => {
                 {_(t.addDevice)}
             </Button>
             <ProvisionDeviceModal
-                closeButtonText={_(t.cancel)}
+                closeButtonText={_(g.close)}
                 deviceAuthCode={code}
                 deviceAuthLoading={fetching}
                 deviceInformation={
@@ -84,13 +88,8 @@ const ProvisionNewDeviceCore = () => {
                 }
                 footerActions={[
                     {
-                        label: _(t.cancel),
-                        onClick: () => setShow(false),
-                        variant: 'tertiary',
-                    },
-                    {
-                        label: _(t.delete),
-                        onClick: () => setShow(false),
+                        label: _(t.close),
+                        onClick: onClose,
                         variant: 'primary',
                     },
                 ]}

--- a/http-gateway/web/src/containers/Devices/List/ProvisionNewDevice/ProvisionNewDevice.tsx
+++ b/http-gateway/web/src/containers/Devices/List/ProvisionNewDevice/ProvisionNewDevice.tsx
@@ -46,6 +46,7 @@ const ProvisionNewDeviceCore = () => {
 
     const openModal = () => {
         setShow(true)
+        localStorage.removeItem(DEVICE_AUTH_CODE_SESSION_KEY)
         sessionStorage.removeItem(DEVICE_AUTH_CODE_SESSION_KEY)
         inputRef?.current?.focus()
     }
@@ -53,6 +54,7 @@ const ProvisionNewDeviceCore = () => {
     const onClose = () => {
         setShow(false)
         setCode(undefined)
+        localStorage.removeItem(DEVICE_AUTH_CODE_SESSION_KEY)
         sessionStorage.removeItem(DEVICE_AUTH_CODE_SESSION_KEY)
         setDeviceId(null)
     }

--- a/http-gateway/web/src/containers/Devices/rest.ts
+++ b/http-gateway/web/src/containers/Devices/rest.ts
@@ -184,6 +184,7 @@ export const getDeviceAuthCode = (deviceId: string) => {
 
             const destroyIframe = () => {
                 sessionStorage.removeItem(DEVICE_AUTH_CODE_SESSION_KEY)
+                localStorage.removeItem(DEVICE_AUTH_CODE_SESSION_KEY)
                 iframe.parentNode?.removeChild(iframe)
             }
 


### PR DESCRIPTION
## Changes Made
- Delete `DEVICE_AUTH_CODE_SESSION_KEY` on the `ProvisionNewDevice` modal open and close event.

## Purpose
The purpose of this change is to ensure that the `DEVICE_AUTH_CODE_SESSION_KEY` is no longer present in the local storage. This modification is necessary for fixing issues during adding new devices.