### PR TITLE
http-gateway: Allow requesting device resources with escaped characters

### DIFF
--- a/http-gateway/service/requestHandler.go
+++ b/http-gateway/service/requestHandler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/plgd-dev/hub/v2/http-gateway/uri"
 	"github.com/plgd-dev/hub/v2/pkg/log"
 	kitHttp "github.com/plgd-dev/hub/v2/pkg/net/http"
+	pkgStrings "github.com/plgd-dev/hub/v2/pkg/strings"
 )
 
 // RequestHandler for handling incoming request
@@ -38,22 +39,30 @@ func matchPrefixAndSplitURIPath(requestURI, prefix string) []string {
 	return strings.Split(p, "/")
 }
 
+func unescapeString(s string) string {
+	newS, err := pkgStrings.Unescape(s, pkgStrings.UnescapingModeAllCharacters, false)
+	if err != nil {
+		return s
+	}
+	return newS
+}
+
 func resourcePendingCommandsMatcher(r *http.Request, rm *mux.RouteMatch) bool {
 	paths := matchPrefixAndSplitURIPath(r.RequestURI, uri.Devices)
 	if len(paths) > 3 && paths[1] == uri.ResourcesPathKey && strings.Contains(paths[len(paths)-1], uri.PendingCommandsPathKey) {
 		if rm.Vars == nil {
 			rm.Vars = make(map[string]string)
 		}
-		rm.Vars[uri.DeviceIDKey] = paths[0]
-		rm.Vars[uri.ResourceHrefKey] = strings.Split("/"+strings.Join(paths[2:len(paths)-1], "/"), "?")[0]
+		rm.Vars[uri.DeviceIDKey] = unescapeString(paths[0])
+		rm.Vars[uri.ResourceHrefKey] = unescapeString(strings.Split("/"+strings.Join(paths[2:len(paths)-1], "/"), "?")[0])
 		return true
 	}
 	if len(paths) > 4 && paths[1] == uri.ResourcesPathKey && strings.Contains(paths[len(paths)-2], uri.PendingCommandsPathKey) {
 		if rm.Vars == nil {
 			rm.Vars = make(map[string]string)
 		}
-		rm.Vars[uri.DeviceIDKey] = paths[0]
-		rm.Vars[uri.ResourceHrefKey] = "/" + strings.Join(paths[2:len(paths)-2], "/")
+		rm.Vars[uri.DeviceIDKey] = unescapeString(paths[0])
+		rm.Vars[uri.ResourceHrefKey] = unescapeString("/" + strings.Join(paths[2:len(paths)-2], "/"))
 		rm.Vars[uri.CorrelationIDKey] = strings.Split(paths[len(paths)-1], "?")[0]
 		return true
 	}
@@ -68,8 +77,8 @@ func resourceMatcher(r *http.Request, rm *mux.RouteMatch) bool {
 		if rm.Vars == nil {
 			rm.Vars = make(map[string]string)
 		}
-		rm.Vars[uri.DeviceIDKey] = paths[0]
-		rm.Vars[uri.ResourceHrefKey] = strings.Split("/"+strings.Join(paths[2:], "/"), "?")[0]
+		rm.Vars[uri.DeviceIDKey] = unescapeString(paths[0])
+		rm.Vars[uri.ResourceHrefKey] = unescapeString(strings.Split("/"+strings.Join(paths[2:], "/"), "?")[0])
 		return true
 	}
 	return false
@@ -81,8 +90,8 @@ func resourceLinksMatcher(r *http.Request, rm *mux.RouteMatch) bool {
 		if rm.Vars == nil {
 			rm.Vars = make(map[string]string)
 		}
-		rm.Vars[uri.DeviceIDKey] = paths[0]
-		rm.Vars[uri.ResourceHrefKey] = strings.Split("/"+strings.Join(paths[2:], "/"), "?")[0]
+		rm.Vars[uri.DeviceIDKey] = unescapeString(paths[0])
+		rm.Vars[uri.ResourceHrefKey] = unescapeString(strings.Split("/"+strings.Join(paths[2:], "/"), "?")[0])
 		return true
 	}
 	return false
@@ -98,8 +107,8 @@ func resourceEventsMatcher(r *http.Request, rm *mux.RouteMatch) bool {
 		if rm.Vars == nil {
 			rm.Vars = make(map[string]string)
 		}
-		rm.Vars[uri.DeviceIDKey] = paths[0]
-		rm.Vars[uri.ResourceHrefKey] = "/" + strings.Join(paths[2:len(paths)-1], "/")
+		rm.Vars[uri.DeviceIDKey] = unescapeString(paths[0])
+		rm.Vars[uri.ResourceHrefKey] = unescapeString("/" + strings.Join(paths[2:len(paths)-1], "/"))
 		return true
 	}
 	return false

--- a/pkg/strings/unescape.go
+++ b/pkg/strings/unescape.go
@@ -1,0 +1,147 @@
+package strings
+
+import (
+	"strconv"
+	"strings"
+)
+
+type MalformedSequenceError string
+
+func (e MalformedSequenceError) Error() string {
+	return "malformed path escape " + strconv.Quote(string(e))
+}
+
+// UnescapingMode defines the behavior of ServeMux when unescaping path parameters.
+type UnescapingMode int
+
+const (
+	// UnescapingModeAllExceptReserved unescapes all path parameters except RFC 6570
+	// reserved characters.
+	UnescapingModeAllExceptReserved UnescapingMode = 1
+
+	// UnescapingModeAllExceptSlash unescapes URL path parameters except path
+	// separators, which will be left as "%2F".
+	UnescapingModeAllExceptSlash UnescapingMode = 2
+
+	// UnescapingModeAllCharacters unescapes all URL path parameters.
+	UnescapingModeAllCharacters UnescapingMode = 3
+)
+
+/*
+ * The following code is adopted and modified from Go's standard library
+ * and carries the attached license.
+ *
+ *     Copyright 2009 The Go Authors. All rights reserved.
+ *     Use of this source code is governed by a BSD-style
+ *     license that can be found in the LICENSE file.
+ */
+
+// isHex returns whether or not the given byte is a valid hex character
+func isHex(c byte) bool {
+	switch {
+	case '0' <= c && c <= '9':
+		return true
+	case 'a' <= c && c <= 'f':
+		return true
+	case 'A' <= c && c <= 'F':
+		return true
+	}
+	return false
+}
+
+func isRFC6570Reserved(c byte) bool {
+	switch c {
+	case '!', '#', '$', '&', '\'', '(', ')', '*',
+		'+', ',', '/', ':', ';', '=', '?', '@', '[', ']':
+		return true
+	default:
+		return false
+	}
+}
+
+// unHex converts a hex point to the bit representation
+func unHex(c byte) byte {
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0'
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10
+	}
+	return 0
+}
+
+// shouldUnescapeWithMode returns true if the character is escapable with the
+// given mode
+func shouldUnescapeWithMode(c byte, mode UnescapingMode) bool {
+	switch mode {
+	case UnescapingModeAllExceptReserved:
+		if isRFC6570Reserved(c) {
+			return false
+		}
+	case UnescapingModeAllExceptSlash:
+		if c == '/' {
+			return false
+		}
+	case UnescapingModeAllCharacters:
+		return true
+	}
+	return true
+}
+
+// checkWellFormed checks if the given string is well-formed
+func checkWellFormed(s string) (bool, error) {
+	n := 0
+	for i := 0; i < len(s); {
+		if s[i] != '%' {
+			i++
+			continue
+		}
+		n++
+		if i+2 >= len(s) || !isHex(s[i+1]) || !isHex(s[i+2]) {
+			s = s[i:]
+			if len(s) > 3 {
+				s = s[:3]
+			}
+			return false, MalformedSequenceError(s)
+		}
+		i += 3
+	}
+	return n != 0, nil
+}
+
+// Unescape unescapes a path string using the provided mode
+func Unescape(s string, mode UnescapingMode, multisegment bool) (string, error) {
+	if !multisegment {
+		mode = UnescapingModeAllCharacters
+	}
+
+	// Count %, check that they're well-formed.
+	needEscape, err := checkWellFormed(s)
+	if err != nil {
+		return "", err
+	}
+	if !needEscape {
+		return s, nil
+	}
+
+	var t strings.Builder
+	t.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '%':
+			c := unHex(s[i+1])<<4 | unHex(s[i+2])
+			if shouldUnescapeWithMode(c, mode) {
+				t.WriteByte(c)
+				i += 2
+				continue
+			}
+			fallthrough
+		default:
+			t.WriteByte(s[i])
+		}
+	}
+
+	return t.String(), nil
+}

--- a/pkg/strings/unescape_internal_test.go
+++ b/pkg/strings/unescape_internal_test.go
@@ -1,0 +1,84 @@
+package strings_test
+
+import (
+	"testing"
+
+	"github.com/plgd-dev/hub/v2/pkg/strings"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnescape(t *testing.T) {
+	tbl := []struct {
+		name         string
+		input        string
+		mode         strings.UnescapingMode
+		multisegment bool
+		expected     string
+		expectedErr  error
+	}{
+		{
+			name:         "No escaping required",
+			input:        "hello world",
+			mode:         strings.UnescapingModeAllCharacters,
+			multisegment: true,
+			expected:     "hello world",
+			expectedErr:  nil,
+		},
+		{
+			name:         "Single character escaping",
+			input:        "/%20",
+			mode:         strings.UnescapingModeAllCharacters,
+			multisegment: true,
+			expected:     "/ ",
+			expectedErr:  nil,
+		},
+		{
+			name:         "Multiple character escaping",
+			input:        "hello%20world",
+			mode:         strings.UnescapingModeAllCharacters,
+			multisegment: true,
+			expected:     "hello world",
+			expectedErr:  nil,
+		},
+		{
+			name:         "Invalid escape sequence",
+			input:        "%2",
+			mode:         strings.UnescapingModeAllCharacters,
+			multisegment: true,
+			expected:     "",
+			expectedErr:  strings.MalformedSequenceError("%2"),
+		},
+		{
+			name:         "Escaping except slash with multisegment=false",
+			input:        "/%2F%23%20",
+			mode:         strings.UnescapingModeAllExceptSlash,
+			multisegment: true,
+			expected:     "/%2F# ",
+			expectedErr:  nil,
+		},
+		{
+			name:         "Escaping except reserved with multisegment=true",
+			input:        "/%2F%23%20",
+			mode:         strings.UnescapingModeAllExceptReserved,
+			multisegment: true,
+			expected:     "/%2F%23 ",
+			expectedErr:  nil,
+		},
+		{
+			name:         "Escaping all characters with multisegment=true",
+			input:        "/%2F%23%20",
+			mode:         strings.UnescapingModeAllCharacters,
+			multisegment: true,
+			expected:     "//# ",
+			expectedErr:  nil,
+		},
+	}
+
+	for _, test := range tbl {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := strings.Unescape(test.input, test.mode, test.multisegment)
+			require.Equal(t, test.expected, result)
+			require.Equal(t, test.expectedErr, err)
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
    - Improved handling of paths in HTTP requests by unescaping strings for better resource matching.
    - Introduced functionality for unescaping path strings with different modes for selective unescaping.
    - Added test cases for the unescaping functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->