### PR TITLE
coap-gateway: Fixing device status to offline when the access token expires

### DIFF
--- a/coap-gateway/service/signIn.go
+++ b/coap-gateway/service/signIn.go
@@ -229,7 +229,11 @@ func getSignInDataFromClaims(ctx context.Context, client *session, signIn CoapSi
 	expTime, _ := jwtClaims.GetExpirationTime()
 	validUntil := time.Time{}
 	if expTime != nil {
-		validUntil = expTime.Time
+		if time.Until(expTime.Time) < 2*client.server.config.APIs.COAP.OwnerCacheExpiration {
+			return "", time.Time{}, fmt.Errorf("access token will expire (%v) in less time than the interval for checking expiration (%v)", expTime.Time, 2*client.server.config.APIs.COAP.OwnerCacheExpiration)
+		}
+		// set expiration time before token expiration to allow sign off device.
+		validUntil = expTime.Time.Add(-2 * client.server.config.APIs.COAP.OwnerCacheExpiration)
 	}
 
 	return deviceID, validUntil, nil


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced testing for device status updates with respect to access token expiration.
- **Bug Fixes**
	- Improved handling of device sign-in when access token is close to expiration, ensuring devices can sign off properly before token expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->