### PR TITLE
coap-gateway: Allows unpublishing multiple resources in a single query

### DIFF
--- a/coap-gateway/service/resourceDirectory.go
+++ b/coap-gateway/service/resourceDirectory.go
@@ -193,11 +193,13 @@ func parseUnpublishQueryString(queries []string) (deviceID string, instanceIDs [
 		if err != nil {
 			return "", nil, fmt.Errorf("cannot parse unpublish query: %w", err)
 		}
-		if di := values.Get("di"); di != "" {
+		for _, di := range values["di"] {
+			if deviceID != "" {
+				return "", nil, fmt.Errorf("unable to parse unpublish query: duplicate in parameter di(%v), previously di(%v)", di, deviceID)
+			}
 			deviceID = di
 		}
-
-		if ins := values.Get("ins"); ins != "" {
+		for _, ins := range values["ins"] {
 			i, err := strconv.Atoi(ins)
 			if err != nil {
 				return "", nil, fmt.Errorf("cannot convert %v to number", ins)

--- a/coap-gateway/service/resourceDirectory_internal_test.go
+++ b/coap-gateway/service/resourceDirectory_internal_test.go
@@ -1,0 +1,71 @@
+//go:build test
+// +build test
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUnpublishQueryString(t *testing.T) {
+	tests := []struct {
+		name        string
+		queries     []string
+		expectedID  string
+		expectedIns []int64
+		wantErr     bool
+	}{
+		{
+			name:        "ValidQueries",
+			queries:     []string{"di=device1", "ins=1", "ins=2"},
+			expectedID:  "device1",
+			expectedIns: []int64{1, 2},
+		},
+		{
+			name:        "MultipleInsInOneQuery",
+			queries:     []string{"di=device1&ins=1&ins=2"},
+			expectedID:  "device1",
+			expectedIns: []int64{1, 2},
+		},
+		{
+			name:    "InvalidIns",
+			queries: []string{"di=device1", "ins=abc"},
+			wantErr: true,
+		},
+		{
+			name:        "One of the queries is invalid",
+			queries:     []string{"di=device1", "ins=1", "invalid_query"},
+			expectedID:  "device1",
+			expectedIns: []int64{1},
+		},
+		{
+			name:    "MultipleDeviceIDs",
+			queries: []string{"di=device1&di=device2"},
+			wantErr: true,
+		},
+		{
+			name:    "DeviceIDandInsAreNotSet",
+			queries: []string{"invalidQuery=123"},
+			wantErr: true,
+		},
+		{
+			name:    "EmptyQueries",
+			queries: []string{},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			deviceID, instanceIDs, err := parseUnpublishQueryString(test.queries)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.Equal(t, test.expectedID, deviceID)
+			require.Equal(t, test.expectedIns, instanceIDs)
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved handling of multiple values for device and instance IDs in unpublish requests to prevent errors and duplicates.

- **Tests**
	- Added tests to ensure correct parsing of unpublish query strings for device and instance IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->