### PR TITLE
tools/proxy-l4: Tunnel connections to alive target

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -109,6 +109,9 @@ jobs:
           - name: cert-tool
             directory: tools/cert-tool
             file: tools/cert-tool/Dockerfile
+          - name: proxy-l4
+            directory: tools/proxy
+            file: tools/proxy/Dockerfile
     uses: ./.github/workflows/build-publish-cfg.yaml
     with:
       name: ${{ matrix.name }}

--- a/tools/proxy/Dockerfile
+++ b/tools/proxy/Dockerfile
@@ -1,0 +1,30 @@
+FROM golang:1.20.14-alpine AS build
+ARG DIRECTORY
+ARG NAME
+ARG VERSION
+ARG COMMIT_DATE
+ARG SHORT_COMMIT
+ARG DATE
+ARG RELEASE_URL
+RUN apk add --no-cache curl git build-base
+WORKDIR $GOPATH/src/github.com/plgd-dev/hub
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+WORKDIR /usr/local/go
+RUN ( patch -p1 < "$GOPATH/src/github.com/plgd-dev/hub/tools/docker/patches/shrink_tls_conn.patch" )
+WORKDIR $GOPATH/src/github.com/plgd-dev/hub/tools/proxy
+RUN CGO_ENABLED=0 go build \
+    -ldflags "-X github.com/plgd-dev/hub/v2/pkg/build.CommitDate=$COMMIT_DATE -X github.com/plgd-dev/hub/v2/pkg/build.CommitHash=$SHORT_COMMIT -X github.com/plgd-dev/hub/v2/pkg/build.BuildDate=$DATE -X github.com/plgd-dev/hub/v2/pkg/build.Version=$VERSION -X github.com/plgd-dev/hub/v2/pkg/build.ReleaseURL=$RELEASE_URL" \
+    -o /go/bin/proxy \
+    ./
+
+FROM alpine:3.19 AS security-provider
+RUN addgroup -S nonroot \
+    && adduser -S nonroot -G nonroot
+
+FROM scratch AS service
+COPY --from=security-provider /etc/passwd /etc/passwd
+COPY --from=build /go/bin/proxy /usr/local/bin/proxy
+USER nonroot
+ENTRYPOINT [ "/usr/local/bin/proxy" ]

--- a/tools/proxy/config.go
+++ b/tools/proxy/config.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/plgd-dev/hub/v2/pkg/config"
+	"github.com/plgd-dev/hub/v2/pkg/log"
+)
+
+type LivenessConfig struct {
+	InitialDelay     time.Duration `json:"initialDelay" yaml:"initialDelay"`
+	Period           time.Duration `json:"period" yaml:"period"`
+	FailureThreshold int           `json:"failureThreshold" yaml:"failureThreshold"`
+}
+
+func (c *LivenessConfig) Validate() error {
+	if c.Period <= 0 {
+		return fmt.Errorf("period(%v) - invalid value", c.Period)
+	}
+	if c.FailureThreshold < 0 {
+		return fmt.Errorf("failureThreshold(%v) - invalid value", c.FailureThreshold)
+	}
+	return nil
+}
+
+type TimeoutsConfig struct {
+	Dial  time.Duration `json:"dial" yaml:"connect"`
+	Read  time.Duration `json:"read" yaml:"read"`
+	Write time.Duration `json:"write" yaml:"write"`
+}
+
+func (c *TimeoutsConfig) Validate() error {
+	if c.Read <= 0 {
+		return fmt.Errorf("dial(%v) - invalid value", c.Dial)
+	}
+	if c.Read <= 0 {
+		return fmt.Errorf("read(%v) - invalid value", c.Read)
+	}
+	if c.Write <= 0 {
+		return fmt.Errorf("write(%v) - invalid value", c.Write)
+	}
+	return nil
+}
+
+type TargetConfig struct {
+	Addr       string         `json:"address" yaml:"address"`
+	Liveness   LivenessConfig `json:"livenessProbe" yaml:"livenessProbe"`
+	Timeouts   TimeoutsConfig `json:"timeouts" yaml:"timeouts"`
+	BufferSize int            `json:"bufferSize" yaml:"bufferSize"`
+}
+
+func (c *TargetConfig) Validate() error {
+	if c.Addr == "" {
+		return fmt.Errorf("address - cannot be empty")
+	}
+	if err := c.Timeouts.Validate(); err != nil {
+		return fmt.Errorf("timeouts.%w", err)
+	}
+	if err := c.Liveness.Validate(); err != nil {
+		return fmt.Errorf("livenessProbe.%w", err)
+	}
+	if c.BufferSize <= 0 {
+		c.BufferSize = 1024
+	}
+	return nil
+}
+
+type TunnelConfig struct {
+	Addr    string         `json:"address" yaml:"address"`
+	Targets []TargetConfig `json:"targets" yaml:"targets"`
+}
+
+func (c *TunnelConfig) Validate() error {
+	if c.Addr == "" {
+		return fmt.Errorf("address - cannot be empty")
+	}
+	l, err := net.Listen("tcp", c.Addr)
+	if err != nil {
+		return fmt.Errorf("address(%v) - %w", c.Addr, err)
+	}
+	_ = l.Close()
+
+	if len(c.Targets) == 0 {
+		return fmt.Errorf("targets - cannot be empty")
+	}
+	for i, target := range c.Targets {
+		if err := target.Validate(); err != nil {
+			return fmt.Errorf("targets[%v].%w", i, err)
+		}
+	}
+	return nil
+}
+
+type TCPConfig struct {
+	Tunnels []TunnelConfig `json:"tunnels" yaml:"tunnels"`
+}
+
+func (c *TCPConfig) Validate() error {
+	if len(c.Tunnels) == 0 {
+		return fmt.Errorf("tunnels - cannot be empty")
+	}
+	for i, tunnel := range c.Tunnels {
+		if err := tunnel.Validate(); err != nil {
+			return fmt.Errorf("tunnels[%v].%w", i, err)
+		}
+	}
+	return nil
+}
+
+type ApisConfig struct {
+	TCP TCPConfig `json:"tcp" yaml:"tcp"`
+}
+
+func (c *ApisConfig) Validate() error {
+	if err := c.TCP.Validate(); err != nil {
+		return fmt.Errorf("tcp.%w", err)
+	}
+	return nil
+}
+
+type DirectoryConfig struct {
+	Path string `json:"path" yaml:"path"`
+}
+
+func (c *DirectoryConfig) Validate() error {
+	if c.Path == "" {
+		return fmt.Errorf("path - cannot be empty")
+	}
+	p, err := os.Stat(c.Path)
+	if err != nil {
+		return fmt.Errorf("path(%v) - %w", c.Path, err)
+	}
+	if !p.IsDir() {
+		return fmt.Errorf("path(%v) - not a directory", c.Path)
+	}
+	testFile := filepath.Clean(c.Path + string(filepath.Separator) + "test.plgd.file")
+	if err := os.WriteFile(testFile, []byte("test"), 0o600); err != nil {
+		return fmt.Errorf("path(%v) - %w", c.Path, err)
+	}
+	if err := os.Remove(testFile); err != nil {
+		return fmt.Errorf("path(%v) - %w", c.Path, err)
+	}
+	return nil
+}
+
+type StorageConfig struct {
+	Directory DirectoryConfig `json:"fileDirectory" yaml:"fileDirectory"`
+}
+
+func (c *StorageConfig) Validate() error {
+	if err := c.Directory.Validate(); err != nil {
+		return fmt.Errorf("fileDirectory.%w", err)
+	}
+	return nil
+}
+
+type ClientsConfig struct {
+	Storage StorageConfig `json:"storage" yaml:"storage"`
+}
+
+func (c *ClientsConfig) Validate() error {
+	if err := c.Storage.Validate(); err != nil {
+		return fmt.Errorf("storage.%w", err)
+	}
+	return nil
+}
+
+type Config struct {
+	Log     log.Config    `json:"log" yaml:"log"`
+	Apis    ApisConfig    `json:"apis" yaml:"apis"`
+	Clients ClientsConfig `json:"clients" yaml:"clients"`
+}
+
+func (c *Config) Validate() error {
+	if err := c.Log.Validate(); err != nil {
+		return fmt.Errorf("log.%w", err)
+	}
+	if err := c.Apis.Validate(); err != nil {
+		return fmt.Errorf("apis.%w", err)
+	}
+	if err := c.Clients.Validate(); err != nil {
+		return fmt.Errorf("clients.%w", err)
+	}
+	return nil
+}
+
+// String return string representation of Config
+func (c Config) String() string {
+	return config.ToString(c)
+}

--- a/tools/proxy/config.go
+++ b/tools/proxy/config.go
@@ -35,7 +35,7 @@ type TimeoutsConfig struct {
 
 func (c *TimeoutsConfig) Validate() error {
 	if c.Read <= 0 {
-		return fmt.Errorf("dial(%v) - invalid value", c.Dial)
+		return fmt.Errorf("read(%v) - invalid value", c.Read)
 	}
 	if c.Read <= 0 {
 		return fmt.Errorf("read(%v) - invalid value", c.Read)

--- a/tools/proxy/config.yaml
+++ b/tools/proxy/config.yaml
@@ -1,0 +1,40 @@
+
+log:
+  level: debug
+  encoding: json
+  stacktrace:
+    enabled: false
+    level: warn
+  encoderConfig:
+    timeEncoder: rfc3339nano
+apis:
+  tcp:
+    tunnels:
+    - address: 0.0.0.0:7000
+      targets:
+      - address: 10.110.110.1:80
+        livenessProbe:
+          period: 10s
+          initialDelay: 5s
+          failureThreshold: 3
+        timeouts:
+          dial: 10s
+          read: 1m
+          write: 10s
+        bufferSize: 4096
+      - address: try.plgd.cloud:5684
+        livenessProbe:
+          period: 10s
+          initialDelay: 5s
+          failureThreshold: 3
+        timeouts:
+          dial: 10s
+          read: 1m
+          write: 10s
+        bufferSize: 4096
+clients:
+  storage:
+    fileDirectory:
+      path: ./
+
+

--- a/tools/proxy/main.go
+++ b/tools/proxy/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/plgd-dev/hub/v2/pkg/build"
+	"github.com/plgd-dev/hub/v2/pkg/config"
+	"github.com/plgd-dev/hub/v2/pkg/log"
+)
+
+func main() {
+	var cfg Config
+	err := config.LoadAndValidateConfig(&cfg)
+	if err != nil {
+		log.Fatalf("cannot load config: %v", err)
+	}
+	logger := log.NewLogger(cfg.Log)
+	log.Set(logger)
+	logger.Debugf("version: %v, buildDate: %v, buildRevision %v", build.Version, build.BuildDate, build.CommitHash)
+	logger.Infof("config: %v", cfg.String())
+
+	state, err := NewState(cfg.Clients.Storage.Directory)
+	if err != nil {
+		logger.Fatalf("cannot initialize state: %v", err)
+	}
+	tunnels := make([]*Tunnel, 0, len(cfg.Apis.TCP.Tunnels))
+	for idx, tunnelConfig := range cfg.Apis.TCP.Tunnels {
+		tunnel, err := NewTunnel(tunnelConfig, state, logger)
+		if err != nil {
+			logger.Fatalf("cannot create tunnel[%v]: %v", idx, err)
+		}
+		tunnels = append(tunnels, tunnel)
+	}
+
+	if cfg.Log.Level == log.DebugLevel {
+		go func() {
+			var m runtime.MemStats
+			for {
+				runtime.ReadMemStats(&m)
+				log.Debugf("memstat Alloc = %v MiB, Sys = %v MiB, numGoroutines = %v", m.Alloc/1024/1024, m.Sys/1024/1024, runtime.NumGoroutine())
+				for _, t := range tunnels {
+					t.logger.Debugf("numConnections = %v", t.numConnections())
+				}
+				time.Sleep(5 * time.Second)
+			}
+		}()
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(tunnels))
+	for _, tunnel := range tunnels {
+		go func(tunnel *Tunnel) {
+			defer wg.Done()
+			err := tunnel.Serve()
+			if err != nil {
+				logger.Fatalf("tunnel serve failed: %v", err)
+			}
+		}(tunnel)
+	}
+	wg.Wait()
+	for _, tunnel := range tunnels {
+		err := tunnel.Close()
+		if err != nil {
+			logger.Errorf("tunnel close failed: %v", err)
+		}
+	}
+}

--- a/tools/proxy/state.go
+++ b/tools/proxy/state.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+type TunnelState struct {
+	SelectedTarget string `json:"selectedTarget" yaml:"selectedTarget"`
+}
+
+type State struct {
+	cfg  DirectoryConfig
+	data map[string]TunnelState // listener address -> state
+	mux  sync.Mutex
+}
+
+func NewState(cfg DirectoryConfig) (*State, error) {
+	s := &State{
+		data: make(map[string]TunnelState),
+		cfg:  cfg,
+	}
+	err := s.load()
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *State) Get(id string) (TunnelState, bool) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	state, ok := s.data[id]
+	return state, ok
+}
+
+func (s *State) Set(id string, state TunnelState) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	s.data[id] = state
+}
+
+func (s *State) getFilePath() string {
+	return s.cfg.Path + string(filepath.Separator) + "state.yaml"
+}
+
+func (s *State) load() error {
+	f, err := os.Open(s.getFilePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+	}
+	defer f.Close()
+	return yaml.NewDecoder(f).Decode(&s.data)
+}
+
+func (s *State) dumpToFile(path string) error {
+	f, err := os.OpenFile(filepath.Clean(s.getFilePath()+".tmp"), os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	err = yaml.NewEncoder(f).Encode(s.data)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *State) Dump() error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	tmpFile := filepath.Clean(s.getFilePath() + ".tmp")
+	err := s.dumpToFile(tmpFile)
+	if err != nil {
+		return err
+	}
+	return os.Rename(tmpFile, s.getFilePath())
+}

--- a/tools/proxy/state.go
+++ b/tools/proxy/state.go
@@ -60,8 +60,8 @@ func (s *State) load() error {
 	return yaml.NewDecoder(f).Decode(&s.data)
 }
 
-func (s *State) dumpToFile() error {
-	f, err := os.OpenFile(filepath.Clean(s.getFilePath()+".tmp"), os.O_CREATE|os.O_WRONLY, 0o600)
+func (s *State) dumpToFile(path string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}

--- a/tools/proxy/state.go
+++ b/tools/proxy/state.go
@@ -60,7 +60,7 @@ func (s *State) load() error {
 	return yaml.NewDecoder(f).Decode(&s.data)
 }
 
-func (s *State) dumpToFile(path string) error {
+func (s *State) dumpToFile() error {
 	f, err := os.OpenFile(filepath.Clean(s.getFilePath()+".tmp"), os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err

--- a/tools/proxy/state.yaml
+++ b/tools/proxy/state.yaml
@@ -1,0 +1,2 @@
+0.0.0.0:7000:
+    selectedTarget: try.plgd.cloud:5684

--- a/tools/proxy/test/main.go
+++ b/tools/proxy/test/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"flag"
+	"net"
+	"sync"
+
+	"github.com/plgd-dev/hub/v2/pkg/log"
+)
+
+func main() {
+	numConn := flag.Int("numConn", 1, "number of connections")
+	addr := flag.String("addr", "127.0.0.1:7000", "address to connect to")
+	flag.Parse()
+	var wg sync.WaitGroup
+	wg.Add(*numConn)
+	for i := 0; i < *numConn; i++ {
+		conn, err := net.Dial("tcp", *addr)
+		if err != nil {
+			log.Fatalf("cannot dial: %v", err)
+		}
+		go func(conn net.Conn) {
+			defer wg.Done()
+			defer conn.Close()
+			buf := make([]byte, 1024)
+			for {
+				n, err := conn.Read(buf)
+				if err != nil {
+					log.Errorf("cannot read: %v", err)
+					return
+				}
+				log.Debugf("read: %v", string(buf[:n]))
+			}
+		}(conn)
+	}
+	wg.Wait()
+}

--- a/tools/proxy/tunnel.go
+++ b/tools/proxy/tunnel.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/plgd-dev/hub/v2/pkg/log"
+)
+
+type Tunnel struct {
+	cfg      TunnelConfig
+	state    *State
+	listener net.Listener
+	failures int
+	logger   log.Logger
+	done     chan struct{}
+
+	private struct {
+		mux   sync.Mutex
+		conns map[string]net.Conn
+	}
+}
+
+func NewTunnel(cfg TunnelConfig, state *State, logger log.Logger) (*Tunnel, error) {
+	listener, err := net.Listen("tcp", cfg.Addr)
+	if err != nil {
+		return nil, err
+	}
+
+	t := &Tunnel{
+		cfg:      cfg,
+		state:    state,
+		listener: listener,
+		logger:   logger.With("tunnel", cfg.Addr),
+		done:     make(chan struct{}),
+	}
+	t.private.conns = make(map[string]net.Conn, 32)
+	return t, nil
+}
+
+func (t *Tunnel) selectNextTarget(selectedTarget TargetConfig) error {
+	nextState := TunnelState{
+		SelectedTarget: t.cfg.Targets[0].Addr,
+	}
+	for i, target := range t.cfg.Targets {
+		if i == len(t.cfg.Targets)-1 {
+			return fmt.Errorf("cannot find next target: all next targets are already used")
+		}
+		if target.Addr == selectedTarget.Addr {
+			nextIndex := (i + 1) % len(t.cfg.Targets)
+			nextState.SelectedTarget = t.cfg.Targets[nextIndex].Addr
+			break
+		}
+	}
+	t.state.Set(t.cfg.Addr, nextState)
+	return t.state.Dump()
+}
+
+func (t *Tunnel) getSelectedTarget() TargetConfig {
+	state, ok := t.state.Get(t.cfg.Addr)
+	if !ok {
+		// If the state is not found, return the first target
+		return t.cfg.Targets[0]
+	}
+
+	for _, target := range t.cfg.Targets {
+		if target.Addr == state.SelectedTarget {
+			return target
+		}
+	}
+
+	// If the selected target is not found, return the first one
+	return t.cfg.Targets[0]
+}
+
+func (t *Tunnel) dropConnections() {
+	t.private.mux.Lock()
+	defer t.private.mux.Unlock()
+
+	for key, conn := range t.private.conns {
+		_ = conn.Close()
+		delete(t.private.conns, key)
+	}
+}
+
+func (t *Tunnel) addConnection(conn net.Conn) TargetConfig {
+	t.private.mux.Lock()
+	defer t.private.mux.Unlock()
+
+	t.private.conns[conn.RemoteAddr().String()] = conn
+	return t.getSelectedTarget()
+}
+
+func (t *Tunnel) removeConnection(conn net.Conn) {
+	t.private.mux.Lock()
+	defer t.private.mux.Unlock()
+
+	delete(t.private.conns, conn.RemoteAddr().String())
+}
+
+func (t *Tunnel) numConnections() int {
+	t.private.mux.Lock()
+	defer t.private.mux.Unlock()
+
+	return len(t.private.conns)
+}
+
+func (t *Tunnel) incrementFailures(target TargetConfig) error {
+	t.failures++
+	if t.failures >= target.Liveness.FailureThreshold {
+		if err := t.selectNextTarget(target); err != nil {
+			return err
+		}
+		t.dropConnections()
+		t.resetFailures()
+		t.logger.Infof("selected next target: %v", t.getSelectedTarget().Addr)
+	}
+	return nil
+}
+
+func (t *Tunnel) resetFailures() {
+	t.failures = 0
+}
+
+func (t *Tunnel) checkLiveness() {
+	var originalTarget TargetConfig
+	for {
+		target := t.getSelectedTarget()
+		if originalTarget.Addr != target.Addr {
+			time.Sleep(target.Liveness.InitialDelay)
+			originalTarget = target
+		}
+		start := time.Now()
+		targetConn, err := net.DialTimeout("tcp", target.Addr, target.Liveness.Period)
+		if err != nil {
+			t.logger.Warnf("target %v is dead", target.Addr)
+			err = t.incrementFailures(target)
+			if err != nil {
+				t.logger.Errorf("failed to increment failures %w", err)
+			}
+		} else {
+			t.logger.Debugf("target %v is alive", target.Addr)
+			_ = targetConn.Close()
+			t.resetFailures()
+		}
+		select {
+		case <-time.After(target.Liveness.Period - time.Since(start)):
+			continue
+		case <-t.done:
+			return
+		}
+	}
+}
+
+func (t *Tunnel) handleConn(conn net.Conn, target TargetConfig) {
+	logger := t.logger.With("client", conn.RemoteAddr(), "target", target.Addr)
+	logger.Debugf("connected")
+	defer func() {
+		logger.Debugf("disconnected")
+		t.removeConnection(conn)
+	}()
+	targetConn, err := net.DialTimeout("tcp", target.Addr, target.Timeouts.Dial)
+	if err != nil {
+		logger.Errorf("cannot dial target: %w", err)
+		_ = conn.Close()
+		return
+	}
+	defer targetConn.Close()
+
+	go func() {
+		defer targetConn.Close()
+		defer conn.Close()
+
+		buffer := make([]byte, target.BufferSize)
+		for {
+			err := targetConn.SetReadDeadline(time.Now().Add(target.Timeouts.Read))
+			if err != nil {
+				logger.Errorf("cannot set read deadline: %w", err)
+				return
+			}
+
+			n, err := targetConn.Read(buffer)
+			if err != nil {
+				logger.Errorf("cannot read from target: %w", err)
+				return
+			}
+
+			err = conn.SetWriteDeadline(time.Now().Add(target.Timeouts.Write))
+			if err != nil {
+				logger.Errorf("cannot set write deadline to client: %w", err)
+				return
+			}
+
+			_, err = conn.Write(buffer[:n])
+			if err != nil {
+				logger.Errorf("cannot write to client: %w", err)
+				return
+			}
+		}
+	}()
+
+	buffer := make([]byte, target.BufferSize)
+	for {
+		err := conn.SetReadDeadline(time.Now().Add(target.Timeouts.Read))
+		if err != nil {
+			logger.Errorf("cannot set read deadline from client: %w", err)
+			return
+		}
+
+		n, err := conn.Read(buffer)
+		if err != nil {
+			logger.Errorf("cannot read from client: %w", err)
+			return
+		}
+
+		err = targetConn.SetWriteDeadline(time.Now().Add(target.Timeouts.Write))
+		if err != nil {
+			logger.Errorf("cannot set write deadline to target: %w", err)
+			return
+		}
+
+		_, err = targetConn.Write(buffer[:n])
+		if err != nil {
+			logger.Errorf("cannot write to target: %w", err)
+			return
+		}
+	}
+}
+
+func (t *Tunnel) Serve() error {
+	go t.checkLiveness()
+
+	for {
+		conn, err := t.listener.Accept()
+		if err != nil {
+			return fmt.Errorf("cannot accept connection: %w", err)
+		}
+		target := t.addConnection(conn)
+		go t.handleConn(conn, target)
+	}
+}
+
+func (t *Tunnel) Close() error {
+	close(t.done)
+	t.dropConnections()
+	return t.listener.Close()
+}


### PR DESCRIPTION
When the designated target is unreachable, the tunnel switches to the next available target and stores the new selection for cold restarts. Resetting the state requires editing or removing the state.yaml file and restarting the proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a robust proxy tool with advanced configuration options.
	- Implemented a TCP client for testing multiple concurrent connections.
- **Enhancements**
	- Enhanced proxy tool with multi-stage build, specific versioning, and security configurations.
	- Added comprehensive configuration options for the proxy tool, including liveness checks, timeouts, and TCP configurations.
	- Developed functionality for managing and persisting tunnel states securely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->