### PR TITLE
m2moauthserver: fix security vulnerability

### DIFF
--- a/charts/plgd-hub/templates/m2m-oauth-server/config.yaml
+++ b/charts/plgd-hub/templates/m2m-oauth-server/config.yaml
@@ -48,8 +48,6 @@ data:
         {{- if $createClient}}
         - id: {{ .id }}
           secretFile: {{ include "plgd-hub.resolveTemplateString" (list $ .secretFile) }}
-          requireDeviceID: {{ .requireDeviceID }}
-          requireOwner: {{ .requireOwner  }}
           accessTokenLifetime: {{ .accessTokenLifetime }}
           allowedGrantTypes:
             {{- range .allowedGrantTypes }}
@@ -63,6 +61,9 @@ data:
             {{- range .allowedScopes }}
             - {{ . | quote }}
             {{- end }}
+          {{- if .insertTokenClaims }}
+          insertTokenClaims: {{ .insertTokenClaims | toYaml | nindent 12 }}
+          {{- end }}          
           {{- if .jwtPrivateKey }}
           {{- if .jwtPrivateKey.enabled }}
           jwtPrivateKey:

--- a/charts/plgd-hub/values.yaml
+++ b/charts/plgd-hub/values.yaml
@@ -2615,8 +2615,6 @@ m2moauthserver:
     deviceIDClaim:
     clients:
       - id: "jwt-private-key"
-        requireOwner: true
-        requireDeviceID: false
         accessTokenLifetime: 0s
         allowedGrantTypes:
           - client_credentials
@@ -2629,8 +2627,6 @@ m2moauthserver:
             endpoints:
       - id: "service"
         secretFile: "{{ include \"plgd-hub.m2moauthserver.getClientServiceSecretFile\" . }}"
-        requireOwner: false
-        requireDeviceID: false
         accessTokenLifetime: 0s
         allowedGrantTypes:
           - client_credentials

--- a/m2m-oauth-server/swagger.yaml
+++ b/m2m-oauth-server/swagger.yaml
@@ -1,0 +1,74 @@
+openapi: 3.0.0
+info:
+  title: m2m-oauth-server API
+  description: API documentation for m2m-oauth-server
+  version: 1.0.0
+paths:
+  /m2m-oauth-server/oauth/token:
+    post:
+      summary: Obtain an OAuth token
+      description: This endpoint is used to obtain an OAuth token by providing the necessary credentials and parameters.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                client_id:
+                  type: string
+                  description: "The client ID."
+                scope:
+                  type: string
+                  description: "The scopes that are requested, separated by space. Must be a subset of the allowed scopes for the client."
+                grant_type:
+                  type: string
+                  description: "The type of grant being used. Only 'client_credentials' is supported."
+                client_assertion_type:
+                  type: string
+                  description: "Specifies the type of client assertion. Only 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer' is supported."
+                client_assertion:
+                  type: string
+                  description: "The JWT token signed by the configured client authority."
+      responses:
+        '200':
+          description: OAuth token obtained successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  access_token:
+                    type: string
+                    description: "The OAuth access token."
+                  token_type:
+                    type: string
+                    description: "The type of token. Typically 'Bearer'."
+                  expires_in:
+                    type: integer
+                    description: "The expiration time of the token in seconds. If not provided, the token will be valid indefinitely."
+                  scope:
+                    type: string
+                    description: "The scopes granted for the token."
+        '401':
+          description: Unauthorized. The request requires valid user authentication.
+
+  /m2m-oauth-server/.well-known/jwks.json:
+    get:
+      summary: Retrieve JSON Web Key Set (JWKS)
+      description: This endpoint retrieves the JSON Web Key Set (JWKS), which contains the public keys used to verify the JWT tokens.
+      responses:
+        '200':
+          description: JSON Web Key Set retrieved successfully
+        '404':
+          description: JWKS not found. The requested JWKS does not exist.
+
+  /m2m-oauth-server/.well-known/openid-configuration:
+    get:
+      summary: Retrieve OpenID Configuration
+      description: This endpoint retrieves the OpenID Configuration, which contains the necessary information for clients to interact with the OAuth server.
+      responses:
+        '200':
+          description: OpenID Configuration retrieved successfully
+        '404':
+          description: OpenID Configuration not found. The requested OpenID Configuration does not exist.

--- a/m2m-oauth-server/test/test.go
+++ b/m2m-oauth-server/test/test.go
@@ -35,19 +35,16 @@ const (
 var ServiceOAuthClient = service.Client{
 	ID:                  "serviceClient",
 	SecretFile:          "data:,serviceClientSecret",
-	RequireDeviceID:     false,
-	RequireOwner:        false,
 	AccessTokenLifetime: 0,
 	AllowedGrantTypes:   []service.GrantType{service.GrantTypeClientCredentials},
 	AllowedAudiences:    nil,
 	AllowedScopes:       nil,
+	InsertTokenClaims:   map[string]interface{}{"hardcodedClaim": true},
 }
 
 var JWTPrivateKeyOAuthClient = service.Client{
 	ID:                  "JWTPrivateKeyClient",
 	SecretFile:          "data:,JWTPrivateKeyClientSecret",
-	RequireDeviceID:     false,
-	RequireOwner:        true,
 	AccessTokenLifetime: 0,
 	AllowedGrantTypes:   []service.GrantType{service.GrantTypeClientCredentials},
 	AllowedAudiences:    nil,
@@ -58,21 +55,9 @@ var JWTPrivateKeyOAuthClient = service.Client{
 	},
 }
 
-var DeviceProvisioningServiceOAuthClient = service.Client{
-	ID:                  "deviceProvisioningServiceClient",
-	SecretFile:          "data:,deviceProvisioningServiceClientSecret",
-	RequireDeviceID:     true,
-	RequireOwner:        true,
-	AccessTokenLifetime: 0,
-	AllowedGrantTypes:   []service.GrantType{service.GrantTypeClientCredentials},
-	AllowedAudiences:    nil,
-	AllowedScopes:       nil,
-}
-
 var OAuthClients = service.OAuthClientsConfig{
 	&ServiceOAuthClient,
 	&JWTPrivateKeyOAuthClient,
-	&DeviceProvisioningServiceOAuthClient,
 }
 
 func MakeConfig(t require.TestingT) service.Config {
@@ -142,8 +127,6 @@ type AccessTokenOptions struct {
 	Host         string
 	ClientID     string
 	ClientSecret string
-	Owner        string
-	DeviceID     string
 	GrantType    string
 	Audience     string
 	JWT          string
@@ -166,18 +149,6 @@ func WithAccessTokenClientID(clientID string) func(opts *AccessTokenOptions) {
 func WithAccessTokenClientSecret(clientSecret string) func(opts *AccessTokenOptions) {
 	return func(opts *AccessTokenOptions) {
 		opts.ClientSecret = clientSecret
-	}
-}
-
-func WithAccessTokenOwner(owner string) func(opts *AccessTokenOptions) {
-	return func(opts *AccessTokenOptions) {
-		opts.Owner = owner
-	}
-}
-
-func WithAccessTokenDeviceID(deviceID string) func(opts *AccessTokenOptions) {
-	return func(opts *AccessTokenOptions) {
-		opts.DeviceID = deviceID
 	}
 }
 
@@ -239,13 +210,6 @@ func GetAccessToken(t *testing.T, expectedCode int, opts ...func(opts *AccessTok
 	reqBody := map[string]interface{}{
 		uri.GrantTypeKey: options.GrantType,
 		uri.ClientIDKey:  options.ClientID,
-	}
-
-	if options.Owner != "" {
-		reqBody[uri.OwnerKey] = options.Owner
-	}
-	if options.DeviceID != "" {
-		reqBody[uri.DeviceIDKey] = options.DeviceID
 	}
 	if options.Audience != "" {
 		reqBody[uri.AudienceKey] = options.Audience

--- a/m2m-oauth-server/uri/uri.go
+++ b/m2m-oauth-server/uri/uri.go
@@ -4,18 +4,16 @@ import "github.com/lestrrat-go/jwx/v2/jwt"
 
 const (
 	ClientIDKey            = "client_id"
+	ClientSecretKey        = "client_secret"
 	ScopeKey               = "scope"
 	GrantTypeKey           = "grant_type"
-	UsernameKey            = "username"
-	PasswordKey            = "password"
 	AudienceKey            = jwt.AudienceKey
-	SubjectKey             = jwt.SubjectKey
 	AccessTokenKey         = "access_token"
-	DeviceIDKey            = "https://plgd.dev/deviceId"
-	OwnerKey               = "https://plgd.dev/owner"
 	ClientAssertionTypeKey = "client_assertion_type"
 	ClientAssertionTypeJWT = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 	ClientAssertionKey     = "client_assertion"
+
+	OriginalTokenClaims = "https://plgd.dev/originalClaims"
 
 	Base                = "/m2m-oauth-server"
 	Token               = Base + "/oauth/token"


### PR DESCRIPTION
### Summary of Changes

The PR primarily addresses security vulnerabilities in the OAuth server by modifying OAuth client configurations and token handling mechanisms. Key changes include:

1. **certificate-authority/service/grpc/signCertificate_test.go**:
   - Updated `TestCertificateAuthorityServerSignCSRWithDifferentPublicKeys` to include OAuth client setup and token claims insertion.

2. **m2m-oauth-server/service/config.go**:
   - Added `InsertTokenClaims` field to the `Client` struct.
   - Removed `RequireDeviceID` and `RequireOwner` fields from the `Client` struct.
   - Updated the `Validate` method accordingly.

3. **m2m-oauth-server/service/token.go**:
   - Modified `makeAccessToken` to incorporate `clientCfg.InsertTokenClaims`.
   - Refactored `tokenRequest` struct, including renaming and reordering fields.
   - Updated `postToken` to use `tokenReq.Secret` instead of `tokenReq.Password`.
   - Simplified validation functions by removing checks for `DeviceID` and `Owner`.

4. **m2m-oauth-server/service/token_test.go**:
   - Simplified `TestGetToken` by removing certain test cases and focusing on core token retrieval tests.

5. **m2m-oauth-server/test/test.go**:
   - Removed `RequireDeviceID` and `RequireOwner` fields from OAuth client declarations.
   - Added `InsertTokenClaims` to `ServiceOAuthClient`.

6. **m2m-oauth-server/uri/uri.go**:
   - Removed several constant declarations and introduced a new constant `OriginalTokenClaims`.

These changes enhance the security and flexibility of the OAuth server by allowing dynamic insertion of token claims and simplifying the validation logic.