### PR TITLE
bundle: configure Lead Resource Type by environment

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -195,11 +195,17 @@ COPY bundle/scylla /scylla
 # global
 ENV FQDN="localhost"
 ENV LOG_DEBUG=false
-ENV JETSTREAM=false
 # supported values: mongo, scylla
 ENV DATABASE=mongo
 ENV OVERRIDE_FILES=false
 ENV HUB_ID="afd434f8-bf61-4729-a258-3c1a67fb0287"
+
+# global - NATS
+ENV LEAD_RESOURCE_TYPE_ENABLED=false
+ENV LEAD_RESOURCE_TYPE_REGEX_FILTER=""
+ENV LEAD_RESOURCE_TYPE_FILTER=""
+ENV LEAD_RESOURCE_TYPE_USE_UUID=false
+ENV JETSTREAM=false
 
 # global - open telemetry collector client
 ENV OPEN_TELEMETRY_EXPORTER_ENABLED=false

--- a/bundle/run.sh
+++ b/bundle/run.sh
@@ -816,10 +816,21 @@ cat /configs/resource-aggregate.yaml | yq e "\
   .clients.eventStore.cqlDB.hosts = [ \"${SCYLLA_HOSTNAME}\" ] |
   .clients.eventStore.cqlDB.port = ${SCYLLA_PORT} |
   .clients.eventBus.nats.url = \"${NATS_URL}\" |
+  .clients.eventBus.nats.leadResourceType.enabled = ${LEAD_RESOURCE_TYPE_ENABLED} |
+  .clients.eventBus.nats.leadResourceType.filter = \"${LEAD_RESOURCE_TYPE_FILTER}\" |
+  .clients.eventBus.nats.leadResourceType.useUUID = ${LEAD_RESOURCE_TYPE_USE_UUID} |
   .clients.eventBus.nats.jetstream = ${JETSTREAM} |
   .clients.identityStore.grpc.address = \"${IDENTITY_STORE_ADDRESS}\"
 " - > /data/resource-aggregate.yaml
 fi
+
+# split LEAD_RESOURCE_TYPE_REGEX_FILTER by comma and add each value to the yaml
+ORIG_IFS=$IFS
+IFS=, read -ra values <<< "$LEAD_RESOURCE_TYPE_REGEX_FILTER"
+IFS=$ORIG_IFS
+for v in "${values[@]}"; do
+   yq e -i ".clients.eventBus.nats.leadResourceType.regexFilter += \"$v\"" /data/resource-aggregate.yaml
+done
 
 echo "starting resource-aggregate"
 resource-aggregate --config /data/resource-aggregate.yaml >$LOGS_PATH/resource-aggregate.log 2>&1 &
@@ -865,6 +876,7 @@ cat /configs/resource-directory.yaml | yq e "\
   .clients.eventStore.cqlDB.hosts = [ \"${SCYLLA_HOSTNAME}\" ] |
   .clients.eventStore.cqlDB.port = ${SCYLLA_PORT} |
   .clients.eventBus.nats.url = \"${NATS_URL}\" |
+  .clients.eventBus.nats.leadResourceType.enabled = ${LEAD_RESOURCE_TYPE_ENABLED} |
   .clients.identityStore.grpc.address = \"${IDENTITY_STORE_ADDRESS}\" |
   .publicConfiguration.authority = \"https://${OAUTH_ENDPOINT}\" |
   .publicConfiguration.coapGateway = \"${COAP_GATEWAY_SCHEME}://${COAP_GATEWAY_EXTERNAL_ADDRESS}\" |
@@ -929,6 +941,7 @@ cat /configs/coap-gateway.yaml | yq e "\
   .clients.openTelemetryCollector.grpc.tls.certFile = \"${OPEN_TELEMETRY_EXPORTER_CERT_FILE}\" |
   .clients.openTelemetryCollector.grpc.tls.useSystemCAPool = true |
   .clients.eventBus.nats.url = \"${NATS_URL}\" |
+  .clients.eventBus.nats.leadResourceType.enabled = ${LEAD_RESOURCE_TYPE_ENABLED} |
   .clients.identityStore.grpc.address = \"${IDENTITY_STORE_ADDRESS}\" |
   .clients.resourceAggregate.grpc.address = \"${RESOURCE_AGGREGATE_ADDRESS}\" |
   .clients.resourceDirectory.grpc.address = \"${RESOURCE_DIRECTORY_ADDRESS}\" |
@@ -984,6 +997,7 @@ cat /configs/coap-gateway.yaml | yq e "\
   .clients.openTelemetryCollector.grpc.tls.certFile = \"${OPEN_TELEMETRY_EXPORTER_CERT_FILE}\" |
   .clients.openTelemetryCollector.grpc.tls.useSystemCAPool = true |
   .clients.eventBus.nats.url = \"${NATS_URL}\" |
+  .clients.eventBus.nats.leadResourceType.enabled = ${LEAD_RESOURCE_TYPE_ENABLED} |
   .clients.identityStore.grpc.address = \"${IDENTITY_STORE_ADDRESS}\" |
   .clients.resourceAggregate.grpc.address = \"${RESOURCE_AGGREGATE_ADDRESS}\" |
   .clients.resourceDirectory.grpc.address = \"${RESOURCE_DIRECTORY_ADDRESS}\" |
@@ -1067,6 +1081,7 @@ cat /configs/grpc-gateway.yaml | yq e "\
   .clients.openTelemetryCollector.grpc.tls.useSystemCAPool = true |
   .clients.identityStore.grpc.address = \"${IDENTITY_STORE_ADDRESS}\" |
   .clients.eventBus.nats.url = \"${NATS_URL}\" |
+  .clients.eventBus.nats.leadResourceType.enabled = ${LEAD_RESOURCE_TYPE_ENABLED} |
   .clients.resourceAggregate.grpc.address = \"${RESOURCE_AGGREGATE_ADDRESS}\" |
   .clients.resourceDirectory.grpc.address = \"${RESOURCE_DIRECTORY_ADDRESS}\" |
   .clients.certificateAuthority.grpc.address = \"${CERTIFICATE_AUTHORITY_ADDRESS}\"
@@ -1165,6 +1180,7 @@ cat /configs/cloud2cloud-gateway.yaml | yq e "\
   .clients.openTelemetryCollector.grpc.tls.certFile = \"${OPEN_TELEMETRY_EXPORTER_CERT_FILE}\" |
   .clients.openTelemetryCollector.grpc.tls.useSystemCAPool = true |
   .clients.eventBus.nats.url = \"${NATS_URL}\" |
+  .clients.eventBus.nats.leadResourceType.enabled = ${LEAD_RESOURCE_TYPE_ENABLED} |
   .clients.grpcGateway.grpc.address = \"${GRPC_GATEWAY_ADDRESS}\" |
   .clients.resourceAggregate.grpc.address = \"${RESOURCE_AGGREGATE_ADDRESS}\" |
   .clients.storage.mongoDB.uri = \"${MONGODB_URI}\" |
@@ -1218,6 +1234,7 @@ cat /configs/cloud2cloud-connector.yaml | yq e "\
   .clients.openTelemetryCollector.grpc.tls.useSystemCAPool = true |
   .clients.identityStore.grpc.address = \"${IDENTITY_STORE_ADDRESS}\" |
   .clients.eventBus.nats.url = \"${NATS_URL}\" |
+  .clients.eventBus.nats.leadResourceType.enabled = ${LEAD_RESOURCE_TYPE_ENABLED} |
   .clients.grpcGateway.grpc.address = \"${GRPC_GATEWAY_ADDRESS}\" |
   .clients.resourceAggregate.grpc.address = \"${RESOURCE_AGGREGATE_ADDRESS}\" |
   .clients.storage.mongoDB.uri = \"${MONGODB_URI}\"


### PR DESCRIPTION
### Overview

This pull request introduces new environment variables and configuration parameters to enhance the flexibility and configurability of the system's NATS client settings to the **bundle** image. These changes allow for better control over the `leadResourceType` feature, enabling or disabling it, and customizing its behavior through various filters and UUID usage.

### Key Changes

1. **New Environment Variables**:
   - `LEAD_RESOURCE_TYPE_ENABLED`: Enables or disables the `leadResourceType` feature. Default is `false`.
   - `LEAD_RESOURCE_TYPE_REGEX_FILTER`: Defines regex patterns for filtering. Default is an empty string.
   - `LEAD_RESOURCE_TYPE_FILTER`: Specifies additional filtering criteria. Default is an empty string.
   - `LEAD_RESOURCE_USE_UUID`: Indicates whether to use UUIDs for the `leadResourceType`. Default is `false`.

2. **Configuration Enhancements**:
   - **Enabled Flag**: The `leadResourceType.enabled` parameter is added to the NATS client settings, controlled by the `LEAD_RESOURCE_TYPE_ENABLED` environment variable.
   - **Filter Parameter**: The `leadResourceType.filter` parameter is introduced, utilizing the `LEAD_RESOURCE_TYPE_FILTER` environment variable.
   - **UUID Usage**: The `leadResourceType.useUUID` parameter is added, governed by the `LEAD_RESOURCE_USE_UUID` environment variable.
   - **Regex Filter Handling**: A new logic block processes the `LEAD_RESOURCE_TYPE_REGEX_FILTER`, splitting the filter string by commas and appending each value to the `regexFilter` property in the configuration.

### Impact

These changes provide a more dynamic and flexible way to manage the `leadResourceType` feature in the system. By leveraging environment variables, developers can easily configure the feature's behavior without modifying the codebase, facilitating deployment and maintenance across different environments.