### PR TITLE
chore: bump Go/Alpine base images, improve tests, and centralize MongoDB error handling

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -12,8 +12,8 @@ jobs:
       matrix:
         include:
           # check support for oldest supported golang version
-          - name: go1.23
-            go-version: "~1.23"
+          - name: go1.25
+            go-version: "~1.25"
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version || '^1.23' }}
+          go-version: ${{ matrix.go-version || '^1.25' }}
           check-latest: true
 
       - run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23" # The Go version to download (if necessary) and use.
+          go-version: "1.25" # The Go version to download (if necessary) and use.
           check-latest: false
           cache: false
 
@@ -32,5 +32,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1.6 # switch to latest if development is unfreezed
+          version: v2.8.0 # switch to latest if development is unfreezed
           args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.23"
+  go: "1.25"
 # issues:
 #   fix: true
 linters:

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04 AS hub-test
 RUN apt-get update \
     && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
-    build-essential ca-certificates curl git make patch lsof sudo \
+    build-essential ca-certificates curl git lsof make patch sudo \
     && apt-get clean \
     && curl --proto "=https" -sSL https://get.docker.com/ | sh
 WORKDIR /

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -8,7 +8,7 @@ WORKDIR /
 # apt: ca-certificates git make sudo
 RUN git clone https://github.com/udhos/update-golang.git \
     && cd update-golang \
-    && sudo RELEASE=1.23.9 ./update-golang.sh \
+    && sudo RELEASE=1.23.9 FORCE_IPV4="-L" ./update-golang.sh \
     && ln -s /usr/local/go/bin/go /usr/bin/go
 WORKDIR $GOPATH/src/github.com/plgd-dev/hub
 COPY go.mod go.sum ./

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -8,7 +8,7 @@ WORKDIR /
 # apt: ca-certificates git make sudo
 RUN git clone https://github.com/udhos/update-golang.git \
     && cd update-golang \
-    && sudo RELEASE=1.23.9 FORCE_IPV4="-L" ./update-golang.sh \
+    && sudo RELEASE=1.25.6 FORCE_IPV4="-L" ./update-golang.sh \
     && ln -s /usr/local/go/bin/go /usr/bin/go
 WORKDIR $GOPATH/src/github.com/plgd-dev/hub
 COPY go.mod go.sum ./

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04 AS hub-test
 RUN apt-get update \
     && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
-    build-essential ca-certificates curl git make patch sudo \
+    build-essential ca-certificates curl git make patch lsof sudo \
     && apt-get clean \
     && curl --proto "=https" -sSL https://get.docker.com/ | sh
 WORKDIR /

--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -202,7 +202,13 @@ RUN go build \
 #device-provisioning-service
 ARG service=device-provisioning-service
 WORKDIR $root_directory/$service
-RUN go build -ldflags "-linkmode external -extldflags -static -X github.com/plgd-dev/hub/v2/pkg/build.CommitDate=$COMMIT_DATE -X github.com/plgd-dev/hub/v2/pkg/build.CommitHash=$SHORT_COMMIT -X github.com/plgd-dev/hub/v2/pkg/build.BuildDate=$DATE -X github.com/plgd-dev/hub/v2/pkg/build.Version=$VERSION -X github.com/plgd-dev/hub/v2/pkg/build.ReleaseURL=$RELEASE_URL" \
+RUN go build \
+    -ldflags "-linkmode external -extldflags -static \
+    -X github.com.plgd-dev/hub/v2/pkg/build.CommitDate=$COMMIT_DATE \
+    -X github.com.plgd-dev/hub/v2/pkg/build.CommitHash=$SHORT_COMMIT \
+    -X github.com.plgd-dev/hub/v2/pkg/build.BuildDate=$DATE \
+    -X github.com.plgd-dev/hub/v2/pkg/build.Version=$VERSION \
+    -X github.com.plgd-dev/hub/v2/pkg/build.ReleaseURL=$RELEASE_URL" \
     -o "/go/bin/$service" \
     ./cmd/service
 
@@ -216,8 +222,8 @@ RUN apkArch="$(apk --print-arch)"; \
     x86_64) ARCH='amd64' ;; \
     *) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
     esac; \
-    curl -L https://github.com/nats-io/nats-server/releases/download/v2.3.1/nats-server-v2.3.1-linux-${ARCH}.zip -o ./nats-server.zip ; \
-    curl -L https://github.com/nats-io/natscli/releases/download/0.0.24/nats-0.0.24-linux-${ARCH}.zip -o ./nats.zip \
+    curl -L "https://github.com/nats-io/nats-server/releases/download/v2.3.1/nats-server-v2.3.1-linux-${ARCH}.zip" -o ./nats-server.zip ; \
+    curl -L "https://github.com/nats-io/natscli/releases/download/0.0.24/nats-0.0.24-linux-${ARCH}.zip" -o ./nats.zip \
     && mkdir -p ./nats-server \
     && unzip ./nats-server.zip -d ./nats-server \
     && cp ./nats-server/*/nats-server /go/bin/nats-server \

--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.23.9-alpine AS build
+FROM golang:1.25.6-alpine AS build
 RUN apk add --no-cache build-base curl git
 WORKDIR $GOPATH/src/github.com/plgd-dev/hub
 COPY go.mod go.sum ./

--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -222,7 +222,7 @@ RUN apkArch="$(apk --print-arch)"; \
     x86_64) ARCH='amd64' ;; \
     *) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
     esac; \
-    curl -L "https://github.com/nats-io/nats-server/releases/download/v2.3.1/nats-server-v2.3.1-linux-${ARCH}.zip" -o ./nats-server.zip ; \
+    curl -L "https://github.com/nats-io/nats-server/releases/download/v2.3.1/nats-server-v2.3.1-linux-${ARCH}.zip" -o ./nats-server.zip && \
     curl -L "https://github.com/nats-io/natscli/releases/download/0.0.24/nats-0.0.24-linux-${ARCH}.zip" -o ./nats.zip \
     && mkdir -p ./nats-server \
     && unzip ./nats-server.zip -d ./nats-server \

--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -204,11 +204,11 @@ ARG service=device-provisioning-service
 WORKDIR $root_directory/$service
 RUN go build \
     -ldflags "-linkmode external -extldflags -static \
-    -X github.com.plgd-dev/hub/v2/pkg/build.CommitDate=$COMMIT_DATE \
-    -X github.com.plgd-dev/hub/v2/pkg/build.CommitHash=$SHORT_COMMIT \
-    -X github.com.plgd-dev/hub/v2/pkg/build.BuildDate=$DATE \
-    -X github.com.plgd-dev/hub/v2/pkg/build.Version=$VERSION \
-    -X github.com.plgd-dev/hub/v2/pkg/build.ReleaseURL=$RELEASE_URL" \
+    -X github.com/plgd-dev/hub/v2/pkg/build.CommitDate=$COMMIT_DATE \
+    -X github.com/plgd-dev/hub/v2/pkg/build.CommitHash=$SHORT_COMMIT \
+    -X github.com/plgd-dev/hub/v2/pkg/build.BuildDate=$DATE \
+    -X github.com/plgd-dev/hub/v2/pkg/build.Version=$VERSION \
+    -X github.com/plgd-dev/hub/v2/pkg/build.ReleaseURL=$RELEASE_URL" \
     -o "/go/bin/$service" \
     ./cmd/service
 

--- a/certificate-authority/service/grpc/signCertificate_test.go
+++ b/certificate-authority/service/grpc/signCertificate_test.go
@@ -34,20 +34,24 @@ func testSigningByFunction(t *testing.T, signFn ClientSignFunc, csr ...[]byte) {
 	type args struct {
 		req *pb.SignCertificateRequest
 	}
-	tests := []struct {
+	tests := make([]struct {
+		name    string
+		args    args
+		want    *pb.SignCertificateResponse
+		wantErr bool
+	}, 0, 1+len(csr))
+	tests = append(tests, struct {
 		name    string
 		args    args
 		want    *pb.SignCertificateResponse
 		wantErr bool
 	}{
-		{
-			name: "invalid csr",
-			args: args{
-				req: &pb.SignCertificateRequest{},
-			},
-			wantErr: true,
+		name: "invalid csr",
+		args: args{
+			req: &pb.SignCertificateRequest{},
 		},
-	}
+		wantErr: true,
+	})
 	for idx, csr := range csr {
 		tests = append(tests, struct {
 			name    string

--- a/certificate-authority/store/mongodb/signingRecords.go
+++ b/certificate-authority/store/mongodb/signingRecords.go
@@ -39,7 +39,7 @@ func (s *Store) UpdateSigningRecord(ctx context.Context, signingRecord *store.Si
 	return err
 }
 
-func toCommonNameQueryFilter(owner string, commonName string) bson.D {
+func toCommonNameQueryFilter(owner, commonName string) bson.D {
 	f := bson.D{
 		{Key: store.CommonNameKey, Value: commonName},
 	}
@@ -49,7 +49,7 @@ func toCommonNameQueryFilter(owner string, commonName string) bson.D {
 	return f
 }
 
-func toDeviceIDQueryFilter(owner string, deviceID string) bson.D {
+func toDeviceIDQueryFilter(owner, deviceID string) bson.D {
 	f := bson.D{
 		{Key: store.DeviceIDKey, Value: deviceID},
 	}
@@ -59,7 +59,7 @@ func toDeviceIDQueryFilter(owner string, deviceID string) bson.D {
 	return f
 }
 
-func toIDQueryFilter(owner string, id string) bson.D {
+func toIDQueryFilter(owner, id string) bson.D {
 	f := bson.D{
 		{Key: "_id", Value: id},
 	}

--- a/certificate-authority/store/mongodb/signingRecords.go
+++ b/certificate-authority/store/mongodb/signingRecords.go
@@ -70,7 +70,8 @@ func toIDQueryFilter(owner string, id string) bson.D {
 }
 
 func toSigningRecordsQueryFilter(owner string, queries *store.SigningRecordsQuery) interface{} {
-	or := []bson.D{}
+	n := len(queries.GetIdFilter()) + len(queries.GetCommonNameFilter()) + len(queries.GetDeviceIdFilter())
+	or := make([]bson.D, 0, n)
 	for _, q := range queries.GetIdFilter() {
 		or = append(or, toIDQueryFilter(owner, q))
 	}

--- a/charts/plgd-hub/Chart.lock
+++ b/charts/plgd-hub/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.1.9
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 15.4.4
+  version: 16.5.45
 - name: scylla
   repository: https://scylla-operator-charts.storage.googleapis.com/stable
   version: v1.10.0
-digest: sha256:2c3e908c6556633c6fd5467498177029023aa737b9436d1001907ecd9ba282ec
-generated: "2024-05-20T14:26:43.823740553Z"
+digest: sha256:9971025d84d32173972f9ab2dee404b98214c98367b93496de63f04d6536a914
+generated: "2026-01-27T10:16:34.731286183+01:00"

--- a/charts/plgd-hub/Chart.yaml
+++ b/charts/plgd-hub/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     repository: "https://nats-io.github.io/k8s/helm/charts/"
     condition: nats.enabled
   - name: "mongodb"
-    version: "15.4.4"
+    version: "16.5.45"
     repository: "https://charts.bitnami.com/bitnami"
     condition: mongodb.enabled
   - name: "scylla"

--- a/charts/plgd-hub/values.yaml
+++ b/charts/plgd-hub/values.yaml
@@ -209,6 +209,7 @@ mongodb:
     enabled: false
   image:
     debug: true
+    registry: public.ecr.aws
   tls:
     enabled: false
   standbyTool:

--- a/charts/plgd-hub/values.yaml
+++ b/charts/plgd-hub/values.yaml
@@ -210,6 +210,9 @@ mongodb:
   image:
     debug: true
     registry: public.ecr.aws
+  global:
+    security:
+      allowInsecureImages: true
   tls:
     enabled: false
   standbyTool:

--- a/cloud2cloud-connector/test/test.go
+++ b/cloud2cloud-connector/test/test.go
@@ -39,7 +39,7 @@ import (
 )
 
 func countOpenFiles() int64 {
-	out, err := exec.Command("/bin/sh", "-c", fmt.Sprintf("lsof -p %v", os.Getpid())).Output()
+	out, err := exec.CommandContext(context.Background(), "/bin/sh", "-c", fmt.Sprintf("lsof -p %v", os.Getpid())).Output()
 	if err != nil {
 		fmt.Println(err.Error())
 	}

--- a/cloud2cloud-gateway/service/subscribeToDevice_test.go
+++ b/cloud2cloud-gateway/service/subscribeToDevice_test.go
@@ -24,7 +24,11 @@ import (
 )
 
 func testSubscribeToDeviceDecodeResources(links ...schema.ResourceLinks) []*commands.Resource {
-	resources := make([]*commands.Resource, 0)
+	total := 0
+	for _, link := range links {
+		total += len(link)
+	}
+	resources := make([]*commands.Resource, 0, total)
 	for _, link := range links {
 		for _, l := range link {
 			pl := commands.SchemaResourceLinkToResource(l, time.Time{})

--- a/coap-gateway/service/service_test.go
+++ b/coap-gateway/service/service_test.go
@@ -52,7 +52,7 @@ func TestServiceConfig(t *testing.T) {
 	cfg.APIs.COAP.Authorization.DeviceIDClaim = ""
 	require.NoError(t, cfg.Validate())
 	var cfg2 coapgwService.Config
-	fmt.Printf(cfg.String())
+	fmt.Printf("%v", cfg.String())
 	err := yaml.Unmarshal([]byte(cfg.String()), &cfg2)
 	require.NoError(t, err)
 	require.NoError(t, cfg2.Validate())

--- a/device-provisioning-service/service/acls.go
+++ b/device-provisioning-service/service/acls.go
@@ -61,47 +61,47 @@ func (RequestHandle) ProcessACLs(_ context.Context, req *mux.Message, session *S
 
 func provisionACLs(req *mux.Message, session *Session, linkedHubs []*LinkedHub) (*pool.Message, []*pb.AccessControl, error) {
 	var resp acl.UpdateRequest
-	allowedHubResources := []acl.Resource{
-		// allow to update device's name from hub
-		{
-			Interfaces: []string{"*"},
-			Href:       configuration.ResourceURI,
-		},
-		// allow to update device from hub
-		{
-			Interfaces: []string{"*"},
-			Href:       softwareupdate.ResourceURI,
-		},
-		// allow to update maintenance from hub
-		{
-			Interfaces: []string{"*"},
-			Href:       maintenance.ResourceURI,
-		},
-		// allow to update time from hub
-		{
-			Interfaces: []string{"*"},
-			Href:       plgdtime.ResourceURI,
-		},
-	}
+	// prepare allowedHubResources with capacity for builtins + allResources
+	allowedHubResources := make([]acl.Resource, 0, 4+len(acl.AllResources))
+	// allow to update device's name from hub
+	allowedHubResources = append(allowedHubResources, acl.Resource{
+		Interfaces: []string{"*"},
+		Href:       configuration.ResourceURI,
+	})
+	// allow to update device from hub
+	allowedHubResources = append(allowedHubResources, acl.Resource{
+		Interfaces: []string{"*"},
+		Href:       softwareupdate.ResourceURI,
+	})
+	// allow to update maintenance from hub
+	allowedHubResources = append(allowedHubResources, acl.Resource{
+		Interfaces: []string{"*"},
+		Href:       maintenance.ResourceURI,
+	})
+	// allow to update time from hub
+	allowedHubResources = append(allowedHubResources, acl.Resource{
+		Interfaces: []string{"*"},
+		Href:       plgdtime.ResourceURI,
+	})
 	// allow to access all resources ordinal resources from hub
 	allowedHubResources = append(allowedHubResources, acl.AllResources...)
 
-	allowedOwnerResources := []acl.Resource{
-		// allow access to cloud configuration resource
-		{
-			Interfaces: []string{"*"},
-			Href:       cloud.ResourceURI,
-		},
-		// allow access security profile resource
-		{
-			Interfaces: []string{"*"},
-			Href:       sp.ResourceURI,
-		},
-		{
-			Interfaces: []string{"*"},
-			Href:       plgdtime.ResourceURI,
-		},
-	}
+	// prepare allowedOwnerResources with capacity for base + allowedHubResources
+	allowedOwnerResources := make([]acl.Resource, 0, 3+len(allowedHubResources))
+	// allow access to cloud configuration resource
+	allowedOwnerResources = append(allowedOwnerResources, acl.Resource{
+		Interfaces: []string{"*"},
+		Href:       cloud.ResourceURI,
+	})
+	// allow access security profile resource
+	allowedOwnerResources = append(allowedOwnerResources, acl.Resource{
+		Interfaces: []string{"*"},
+		Href:       sp.ResourceURI,
+	})
+	allowedOwnerResources = append(allowedOwnerResources, acl.Resource{
+		Interfaces: []string{"*"},
+		Href:       plgdtime.ResourceURI,
+	})
 	allowedOwnerResources = append(allowedOwnerResources, allowedHubResources...)
 
 	resp.AccessControlList = []acl.AccessControl{

--- a/device-provisioning-service/store/mongodb/enrollmentGroups.go
+++ b/device-provisioning-service/store/mongodb/enrollmentGroups.go
@@ -158,7 +158,7 @@ func (i *watchIterator) Next(ctx context.Context) (event store.Event, id string,
 		return "", "", false
 	}
 	var v StreamEnrollmentGroupEvent
-	if err := i.iter.Decode(&v); err != nil {
+	if i.iter.Decode(&v) != nil {
 		return "", "", false
 	}
 	if v.DocumentKey != nil {

--- a/device-provisioning-service/store/mongodb/enrollmentGroups.go
+++ b/device-provisioning-service/store/mongodb/enrollmentGroups.go
@@ -60,7 +60,7 @@ func addOwnerToFilter(owner string, q bson.D) bson.D {
 }
 
 func toEnrollmentGroupIDFilter(owner string, queries *store.EnrollmentGroupsQuery) ([]bson.D, *mongo.IndexModel) {
-	or := []bson.D{}
+	or := make([]bson.D, 0, len(queries.GetIdFilter()))
 	for _, q := range queries.GetIdFilter() {
 		or = append(or, addOwnerToFilter(owner, bson.D{
 			{Key: store.IDKey, Value: q},

--- a/device-provisioning-service/store/mongodb/hubs.go
+++ b/device-provisioning-service/store/mongodb/hubs.go
@@ -49,7 +49,8 @@ func (s *Store) UpdateHub(ctx context.Context, owner string, hub *store.Hub) err
 }
 
 func toHubFilter(owner string, queries *store.HubsQuery) bson.D {
-	or := []bson.D{}
+	n := len(queries.GetIdFilter()) + len(queries.GetHubIdFilter())
+	or := make([]bson.D, 0, n)
 	for _, q := range queries.GetIdFilter() {
 		or = append(or, addOwnerToFilter(owner, bson.D{{Key: store.IDKey, Value: q}}))
 	}

--- a/device-provisioning-service/store/mongodb/provisionedRecords.go
+++ b/device-provisioning-service/store/mongodb/provisionedRecords.go
@@ -43,7 +43,7 @@ func (s *Store) UpdateProvisioningRecord(_ context.Context, owner string, provis
 }
 
 func toProvisioningRecordsQueryFilter(owner string, queries *store.ProvisioningRecordsQuery) bson.D {
-	or := []bson.D{}
+	or := make([]bson.D, 0, len(queries.GetIdFilter())+len(queries.GetEnrollmentGroupIdFilter())+len(queries.GetDeviceIdFilter())+1)
 	for _, q := range queries.GetIdFilter() {
 		or = append(or, addOwnerToFilter(owner, bson.D{{Key: store.IDKey, Value: q}}))
 	}

--- a/device-provisioning-service/test/util.go
+++ b/device-provisioning-service/test/util.go
@@ -1,23 +1,24 @@
 package test
 
 import (
+	"context"
 	"os/exec"
 
 	"github.com/plgd-dev/kit/v2/codec/json"
 )
 
 func RestartDockerContainer(dockerName string) error {
-	cmd := exec.Command("docker", "restart", dockerName)
+	cmd := exec.CommandContext(context.Background(), "docker", "restart", dockerName)
 	return cmd.Run()
 }
 
 func SendSignalToDocker(dockerName, signal string) error {
-	cmd := exec.Command("docker", "kill", "-s", signal, dockerName)
+	cmd := exec.CommandContext(context.Background(), "docker", "kill", "-s", signal, dockerName)
 	return cmd.Run()
 }
 
 func SendSignalToProcess(pid, signal string) error {
-	cmd := exec.Command("kill", "-s", signal, pid)
+	cmd := exec.CommandContext(context.Background(), "kill", "-s", signal, pid)
 	return cmd.Run()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,6 @@
 module github.com/plgd-dev/hub/v2
 
-go 1.23.0
-
-// use export GOTOOLCHAIN=go1.23.0 before calling go mod tidy to avoid tidy adding
-// the toolchain directive with your local go version
+go 1.25
 
 require (
 	github.com/favadi/protoc-go-inject-tag v1.4.0
@@ -149,4 +146,4 @@ require (
 )
 
 // last versions for Go 1.23
-replace github.com/go-json-experiment/json => github.com/go-json-experiment/json v0.0.0-20240815175050-ebd3a8989ca1
+//replace github.com/go-json-experiment/json => github.com/go-json-experiment/json v0.0.0-20240815175050-ebd3a8989ca1

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/ugorji/go/codec v1.2.14
 	github.com/vincent-petithory/dataurl v1.0.0
 	github.com/web-of-things-open-source/thingdescription-go v0.0.0-20250521114616-3895cda67f5d
-	go.mongodb.org/mongo-driver v1.17.3
+	go.mongodb.org/mongo-driver v1.17.7
 	go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo v0.61.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj2
 github.com/go-acme/lego v2.7.2+incompatible/go.mod h1:yzMNe9CasVUhkquNvti5nAtPmG94USbYxYrZfTkIn0M=
 github.com/go-co-op/gocron/v2 v2.16.2 h1:r08P663ikXiulLT9XaabkLypL/W9MoCIbqgQoAutyX4=
 github.com/go-co-op/gocron/v2 v2.16.2/go.mod h1:4YTLGCCAH75A5RlQ6q+h+VacO7CgjkgP0EJ+BEOXRSI=
-github.com/go-json-experiment/json v0.0.0-20240815175050-ebd3a8989ca1 h1:xcuWappghOVI8iNWoF2OKahVejd1LSVi/v4JED44Amo=
-github.com/go-json-experiment/json v0.0.0-20240815175050-ebd3a8989ca1/go.mod h1:BWmvoE1Xia34f3l/ibJweyhrT+aROb/FQ6d+37F0e2s=
+github.com/go-json-experiment/json v0.0.0-20240815174924-0599f16bf0e2 h1:T01ryfhob+ta3ADOh2B2FLA1cFLVOaQJH/iwh22rIFM=
+github.com/go-json-experiment/json v0.0.0-20240815174924-0599f16bf0e2/go.mod h1:uDEMZSTQMj7V6Lxdrx4ZwchmHEGdICbjuY+GQd7j9LM=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/go.sum
+++ b/go.sum
@@ -367,6 +367,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.mongodb.org/mongo-driver v1.17.3 h1:TQyXhnsWfWtgAhMtOgtYHMTkZIfBTpMTsMnd9ZBeHxQ=
 go.mongodb.org/mongo-driver v1.17.3/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
+go.mongodb.org/mongo-driver v1.17.7 h1:a9w+U3Vt67eYzcfq3k/OAv284/uUUkL0uP75VE5rCOU=
+go.mongodb.org/mongo-driver v1.17.7/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo v0.61.0 h1:60BQjL3MUzaYUT8uHfpAFSEe3JOiBT+p19fA/CDOEak=

--- a/grpc-gateway/subscription/convertToSubjects_test.go
+++ b/grpc-gateway/subscription/convertToSubjects_test.go
@@ -163,9 +163,12 @@ func TestConvertToSubjects(t *testing.T) {
 				owner: "c",
 			},
 			want: func() []string {
-				subjects := []string{isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID(resourceID.GetDeviceId()), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType()))}
-				subjects = append(subjects, utils.GetResourceEventSubjects("c", resourceID, (&events.ResourceChanged{}).EventType(), false)...)
-				return append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
+				resourceSubjects := utils.GetResourceEventSubjects("c", resourceID, (&events.ResourceChanged{}).EventType(), false)
+				subjects := make([]string, 0, 2+len(resourceSubjects))
+				subjects = append(subjects, isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID(resourceID.GetDeviceId()), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType())))
+				subjects = append(subjects, resourceSubjects...)
+				subjects = append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
+				return subjects
 			}(),
 		},
 		{
@@ -182,9 +185,12 @@ func TestConvertToSubjects(t *testing.T) {
 				leadRTEnabled: true,
 			},
 			want: func() []string {
-				subjects := []string{isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID(resourceID.GetDeviceId()), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType()))}
-				subjects = append(subjects, utils.GetResourceEventSubjects("c", resourceID, (&events.ResourceChanged{}).EventType(), true)...)
-				return append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
+				resourceSubjects := utils.GetResourceEventSubjects("c", resourceID, (&events.ResourceChanged{}).EventType(), true)
+				subjects := make([]string, 0, 2+len(resourceSubjects))
+				subjects = append(subjects, isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID(resourceID.GetDeviceId()), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType())))
+				subjects = append(subjects, resourceSubjects...)
+				subjects = append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
+				return subjects
 			}(),
 		},
 		{
@@ -199,9 +205,12 @@ func TestConvertToSubjects(t *testing.T) {
 				owner: "c",
 			},
 			want: func() []string {
-				subjects := []string{isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID("*"), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType()))}
-				subjects = append(subjects, utils.GetResourceEventSubjects("c", commands.NewResourceID("*", resourceID.GetHref()), (&events.ResourceChanged{}).EventType(), false)...)
-				return append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
+				resourceSubjects := utils.GetResourceEventSubjects("c", commands.NewResourceID("*", resourceID.GetHref()), (&events.ResourceChanged{}).EventType(), false)
+				subjects := make([]string, 0, 2+len(resourceSubjects))
+				subjects = append(subjects, isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID("*"), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType())))
+				subjects = append(subjects, resourceSubjects...)
+				subjects = append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
+				return subjects
 			}(),
 		},
 		{
@@ -217,9 +226,12 @@ func TestConvertToSubjects(t *testing.T) {
 				leadRTEnabled: true,
 			},
 			want: func() []string {
-				subjects := []string{isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID("*"), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType()))}
-				subjects = append(subjects, utils.GetResourceEventSubjects("c", commands.NewResourceID("*", resourceID.GetHref()), (&events.ResourceChanged{}).EventType(), true)...)
-				return append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
+				resourceSubjects := utils.GetResourceEventSubjects("c", commands.NewResourceID("*", resourceID.GetHref()), (&events.ResourceChanged{}).EventType(), true)
+				subjects := make([]string, 0, 2+len(resourceSubjects))
+				subjects = append(subjects, isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID("*"), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType())))
+				subjects = append(subjects, resourceSubjects...)
+				subjects = append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
+				return subjects
 			}(),
 		},
 		{
@@ -234,9 +246,12 @@ func TestConvertToSubjects(t *testing.T) {
 				owner: "c",
 			},
 			want: func() []string {
-				subjects := []string{isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID("*"), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType()))}
-				subjects = append(subjects, utils.GetResourceEventSubjects("c", commands.NewResourceID("*", resourceID.GetHref()), (&events.ResourceChanged{}).EventType(), false)...)
-				return append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
+				resourceSubjects := utils.GetResourceEventSubjects("c", commands.NewResourceID("*", resourceID.GetHref()), (&events.ResourceChanged{}).EventType(), false)
+				subjects := make([]string, 0, 2+len(resourceSubjects))
+				subjects = append(subjects, isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID("*"), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType())))
+				subjects = append(subjects, resourceSubjects...)
+				subjects = append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
+				return subjects
 			}(),
 		},
 		{
@@ -252,8 +267,10 @@ func TestConvertToSubjects(t *testing.T) {
 				leadRTEnabled: true,
 			},
 			want: func() []string {
-				subjects := []string{isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID("*"), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType()))}
-				subjects = append(subjects, utils.GetResourceEventSubjects("c", commands.NewResourceID("*", resourceID.GetHref()), (&events.ResourceChanged{}).EventType(), true)...)
+				resourceSubjects := utils.GetResourceEventSubjects("c", commands.NewResourceID("*", resourceID.GetHref()), (&events.ResourceChanged{}).EventType(), true)
+				subjects := make([]string, 0, 2+len(resourceSubjects))
+				subjects = append(subjects, isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID("*"), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType())))
+				subjects = append(subjects, resourceSubjects...)
 				return append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
 			}(),
 		},
@@ -270,9 +287,12 @@ func TestConvertToSubjects(t *testing.T) {
 				owner: "c",
 			},
 			want: func() []string {
-				subjects := []string{isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID(resourceID.GetDeviceId()), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType()))}
-				subjects = append(subjects, utils.GetResourceEventSubjects("c", commands.NewResourceID(resourceID.GetDeviceId(), "*"), (&events.ResourceChanged{}).EventType(), false)...)
-				return append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
+				resourceSubjects := utils.GetResourceEventSubjects("c", commands.NewResourceID(resourceID.GetDeviceId(), "*"), (&events.ResourceChanged{}).EventType(), false)
+				subjects := make([]string, 0, 2+len(resourceSubjects))
+				subjects = append(subjects, isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID(resourceID.GetDeviceId()), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType())))
+				subjects = append(subjects, resourceSubjects...)
+				subjects = append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
+				return subjects
 			}(),
 		},
 		{
@@ -289,9 +309,12 @@ func TestConvertToSubjects(t *testing.T) {
 				leadRTEnabled: true,
 			},
 			want: func() []string {
-				subjects := []string{isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID(resourceID.GetDeviceId()), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType()))}
-				subjects = append(subjects, utils.GetResourceEventSubjects("c", commands.NewResourceID(resourceID.GetDeviceId(), "*"), (&events.ResourceChanged{}).EventType(), true)...)
-				return append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
+				resourceSubjects := utils.GetResourceEventSubjects("c", commands.NewResourceID(resourceID.GetDeviceId(), "*"), (&events.ResourceChanged{}).EventType(), true)
+				subjects := make([]string, 0, 2+len(resourceSubjects))
+				subjects = append(subjects, isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID(resourceID.GetDeviceId()), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType())))
+				subjects = append(subjects, resourceSubjects...)
+				subjects = append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
+				return subjects
 			}(),
 		},
 		{
@@ -308,8 +331,10 @@ func TestConvertToSubjects(t *testing.T) {
 				owner: "c",
 			},
 			want: func() []string {
-				subjects := []string{isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID(resourceID.GetDeviceId()), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType()))}
-				subjects = append(subjects, utils.GetResourceEventSubjects("c", resourceID, (&events.ResourceChanged{}).EventType(), false)...)
+				resourceSubjects := utils.GetResourceEventSubjects("c", resourceID, (&events.ResourceChanged{}).EventType(), false)
+				subjects := make([]string, 0, 2+len(resourceSubjects))
+				subjects = append(subjects, isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID(resourceID.GetDeviceId()), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType())))
+				subjects = append(subjects, resourceSubjects...)
 				return append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
 			}(),
 		},
@@ -328,8 +353,10 @@ func TestConvertToSubjects(t *testing.T) {
 				leadRTEnabled: true,
 			},
 			want: func() []string {
-				subjects := []string{isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID(resourceID.GetDeviceId()), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType()))}
-				subjects = append(subjects, utils.GetResourceEventSubjects("c", resourceID, (&events.ResourceChanged{}).EventType(), true)...)
+				resourceSubjects := utils.GetResourceEventSubjects("c", resourceID, (&events.ResourceChanged{}).EventType(), true)
+				subjects := make([]string, 0, 2+len(resourceSubjects))
+				subjects = append(subjects, isEvents.ToSubject(utils.PlgdOwnersOwnerDevicesDeviceMetadataEvent, isEvents.WithOwner("c"), utils.WithDeviceID(resourceID.GetDeviceId()), isEvents.WithEventType((&events.DeviceMetadataUpdated{}).EventType())))
+				subjects = append(subjects, resourceSubjects...)
 				return append(subjects, isEvents.ToSubject(isEvents.PlgdOwnersOwnerRegistrations+".>", isEvents.WithOwner("c")))
 			}(),
 		},

--- a/http-gateway/Dockerfile
+++ b/http-gateway/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.23.9-alpine AS build
+FROM golang:1.25.6-alpine AS build
 ARG VERSION
 ARG COMMIT_DATE
 ARG SHORT_COMMIT
@@ -27,7 +27,7 @@ RUN go build \
     -o /go/bin/http-gateway \
     ./cmd/service
 
-FROM alpine:3.22 AS security-provider
+FROM alpine:3.23 AS security-provider
 RUN apk add -U --no-cache ca-certificates \
     && addgroup -S nonroot \
     && adduser -S nonroot -G nonroot

--- a/http-gateway/serverMux/serverMux.go
+++ b/http-gateway/serverMux/serverMux.go
@@ -7,11 +7,10 @@ import (
 
 // New creates default server mux
 func New(opts ...runtime.ServeMuxOption) *runtime.ServeMux {
-	intOpts := []runtime.ServeMuxOption{
-		runtime.WithErrorHandler(ErrorHandler),
-		runtime.WithMarshalerOption(pkgHttp.ApplicationProtoJsonContentType, NewJsonpbMarshaler()),
-		runtime.WithMarshalerOption(runtime.MIMEWildcard, NewJsonMarshaler()),
-	}
+	intOpts := make([]runtime.ServeMuxOption, 0, 3+len(opts))
+	intOpts = append(intOpts, runtime.WithErrorHandler(ErrorHandler))
+	intOpts = append(intOpts, runtime.WithMarshalerOption(pkgHttp.ApplicationProtoJsonContentType, NewJsonpbMarshaler()))
+	intOpts = append(intOpts, runtime.WithMarshalerOption(runtime.MIMEWildcard, NewJsonMarshaler()))
 	intOpts = append(intOpts, opts...)
 	return runtime.NewServeMux(intOpts...)
 }

--- a/http-gateway/web/package-lock.json
+++ b/http-gateway/web/package-lock.json
@@ -6121,10 +6121,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.11",
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@swc/types": {
@@ -8923,9 +8925,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001701",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz",
-      "integrity": "sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==",
+      "version": "1.0.30001766",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
+      "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
       "funding": [
         {
           "type": "opencollective",
@@ -29676,7 +29678,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/tsutils": {

--- a/pkg/net/grpc/server/makeDefaultOptions.go
+++ b/pkg/net/grpc/server/makeDefaultOptions.go
@@ -195,20 +195,18 @@ func wrapServerStream(ctx context.Context, ss grpc.ServerStream) *serverStream {
 }
 
 func MakeDefaultOptions(auth pkgGrpc.AuthInterceptors, logger log.Logger, tracerProvider trace.TracerProvider) ([]grpc.ServerOption, error) {
-	streamInterceptors := []grpc.StreamServerInterceptor{
-		func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-			if !info.IsClientStream {
-				return handler(srv, wrapServerStream(ss.Context(), ss))
-			}
-			return handler(srv, ss)
-		},
-	}
-	unaryInterceptors := []grpc.UnaryServerInterceptor{
-		func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
-			setGrpcRequest(ctx, req)
-			return handler(ctx, req)
-		},
-	}
+	streamInterceptors := make([]grpc.StreamServerInterceptor, 0, 3)
+	streamInterceptors = append(streamInterceptors, func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if !info.IsClientStream {
+			return handler(srv, wrapServerStream(ss.Context(), ss))
+		}
+		return handler(srv, ss)
+	})
+	unaryInterceptors := make([]grpc.UnaryServerInterceptor, 0, 3)
+	unaryInterceptors = append(unaryInterceptors, func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		setGrpcRequest(ctx, req)
+		return handler(ctx, req)
+	})
 
 	cfg := logger.Config()
 	if cfg.EncoderConfig.EncodeTime.TimeEncoder == nil {

--- a/pkg/net/grpc/server/newServer.go
+++ b/pkg/net/grpc/server/newServer.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -22,7 +23,7 @@ type Server struct {
 // NewServer instantiates a gRPC server.
 // When passing addr with an unspecified port or ":", use Addr().
 func NewServer(addr string, opts ...grpc.ServerOption) (*Server, error) {
-	lis, err := net.Listen("tcp", addr)
+	lis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("listening failed: %w", err)
 	}

--- a/resource-aggregate/cqrs/eventstore/mongodb/acceptance_testing_test.go
+++ b/resource-aggregate/cqrs/eventstore/mongodb/acceptance_testing_test.go
@@ -268,6 +268,7 @@ func AcceptanceTest(ctx context.Context, t *testing.T, store eventstore.EventSto
 
 	bigEv.VersionI++
 	saveStatus, err = store.Save(ctx, bigEv)
+	t.Logf("saver error: type %T, value %v", err, err)
 	require.NoError(t, err)
 	require.Equal(t, eventstore.SnapshotRequired, saveStatus)
 
@@ -275,7 +276,8 @@ func AcceptanceTest(ctx context.Context, t *testing.T, store eventstore.EventSto
 	saveStatus, err = store.Save(ctx, bigEv)
 	require.NoError(t, err)
 	require.Equal(t, eventstore.Ok, saveStatus)
-	exp := []eventstore.Event{bigEv}
+	exp := make([]eventstore.Event, 0, 2)
+	exp = append(exp, bigEv)
 
 	bigEv.VersionI++
 	bigEv.IsSnapshotI = false

--- a/resource-aggregate/cqrs/eventstore/mongodb/acceptance_testing_test.go
+++ b/resource-aggregate/cqrs/eventstore/mongodb/acceptance_testing_test.go
@@ -268,7 +268,9 @@ func AcceptanceTest(ctx context.Context, t *testing.T, store eventstore.EventSto
 
 	bigEv.VersionI++
 	saveStatus, err = store.Save(ctx, bigEv)
-	t.Logf("saver error: type %T, value %v", err, err)
+	if err != nil {
+		t.Logf("saver error: type %T, value %v", err, err)
+	}
 	require.NoError(t, err)
 	require.Equal(t, eventstore.SnapshotRequired, saveStatus)
 

--- a/resource-aggregate/cqrs/eventstore/mongodb/save.go
+++ b/resource-aggregate/cqrs/eventstore/mongodb/save.go
@@ -77,38 +77,37 @@ func (s *EventStore) saveEvent(ctx context.Context, col *mongo.Collection, event
 	}
 
 	res, err := col.UpdateOne(ctx, filter, update, opts)
-	switch {
-	case err == nil:
+	if err == nil {
 		if res.ModifiedCount == 0 {
 			return eventstore.ConcurrencyException, nil
 		}
 		return eventstore.Ok, nil
-	case errors.Is(err, mongo.ErrNilDocument):
+	}
+	if errors.Is(err, mongo.ErrNilDocument) {
 		return eventstore.ConcurrencyException, nil
-	default:
-		// Try to detect document-too-large in multiple driver/server variants.
-		var wErr mongo.WriteException
-		if errors.As(err, &wErr) {
-			sizeIsExceeded := wErr.HasErrorCode(10334)
-			if sizeIsExceeded {
-				return eventstore.SnapshotRequired, nil
-			}
-			return eventstore.Fail, fmt.Errorf("cannot push events('%v') to db: %w", events, err)
-		}
-		// Some MongoDB server/driver versions return other error types/messages
-		// when a document grows too large (e.g. BSONObjTooLarge, BSONObjectTooLarge,
-		// or other textual variants). Detect common substrings and treat them
-		// as snapshot-required rather than failing the test.
-		msg := ""
-		if err != nil {
-			msg = err.Error()
-		}
-		lowered := strings.ToLower(msg)
-		if strings.Contains(lowered, "bsonobjtoolarge") || strings.Contains(lowered, "bsonobjecttoolarge") || strings.Contains(lowered, "document too large") || strings.Contains(lowered, "object to large") || strings.Contains(lowered, "exceeded maximum bson size") {
+	}
+	return handleUpdateOneError(err, events)
+}
+
+func handleUpdateOneError(err error, events []eventstore.Event) (eventstore.SaveStatus, error) {
+	// Try to detect document-too-large in multiple driver/server variants.
+	var wErr mongo.WriteException
+	if errors.As(err, &wErr) {
+		if wErr.HasErrorCode(10334) {
 			return eventstore.SnapshotRequired, nil
 		}
 		return eventstore.Fail, fmt.Errorf("cannot push events('%v') to db: %w", events, err)
 	}
+	// Some MongoDB server/driver versions return other error types/messages
+	// when a document grows too large (e.g. BSONObjTooLarge, BSONObjectTooLarge,
+	// or other textual variants). Detect common substrings and treat them
+	// as snapshot-required rather than failing the test.
+	msg := err.Error()
+	lowered := strings.ToLower(msg)
+	if strings.Contains(lowered, "bsonobjtoolarge") || strings.Contains(lowered, "bsonobjecttoolarge") || strings.Contains(lowered, "document too large") || strings.Contains(lowered, "object to large") || strings.Contains(lowered, "exceeded maximum bson size") {
+		return eventstore.SnapshotRequired, nil
+	}
+	return eventstore.Fail, fmt.Errorf("cannot push events('%v') to db: %w", events, err)
 }
 
 // Save save events to eventstore.

--- a/resource-aggregate/cqrs/eventstore/mongodb/save.go
+++ b/resource-aggregate/cqrs/eventstore/mongodb/save.go
@@ -106,7 +106,7 @@ func handleUpdateOneError(err error, events []eventstore.Event) (eventstore.Save
 		strings.Contains(lowered, "bsonobjecttoolarge") ||
 		strings.Contains(lowered, "document too large") ||
 		strings.Contains(lowered, "object too large") || // correct spelling
-		strings.Contains(lowered, "object to large") ||  // keep legacy/typo variant
+		strings.Contains(lowered, "object to large") || // keep legacy/typo variant
 		strings.Contains(lowered, "exceeded maximum bson size") ||
 		strings.Contains(lowered, "document after update is larger than") {
 		return eventstore.SnapshotRequired, nil

--- a/resource-aggregate/cqrs/eventstore/mongodb/save.go
+++ b/resource-aggregate/cqrs/eventstore/mongodb/save.go
@@ -100,9 +100,15 @@ func handleUpdateOneError(err error, events []eventstore.Event) (eventstore.Save
 	// Some MongoDB server/driver versions return other error types/messages
 	// when a document grows too large (e.g. BSONObjTooLarge, BSONObjectTooLarge,
 	// or other textual variants). Detect common substrings and treat them
-	// as snapshot-required rather than failing the test.
+	// as snapshot-required at runtime (return SnapshotRequired instead of failing the save).
 	lowered := strings.ToLower(err.Error())
-	if strings.Contains(lowered, "bsonobjtoolarge") || strings.Contains(lowered, "bsonobjecttoolarge") || strings.Contains(lowered, "document too large") || strings.Contains(lowered, "object to large") || strings.Contains(lowered, "exceeded maximum bson size") || strings.Contains(lowered, "document after update is larger than") {
+	if strings.Contains(lowered, "bsonobjtoolarge") ||
+		strings.Contains(lowered, "bsonobjecttoolarge") ||
+		strings.Contains(lowered, "document too large") ||
+		strings.Contains(lowered, "object too large") || // correct spelling
+		strings.Contains(lowered, "object to large") ||  // keep legacy/typo variant
+		strings.Contains(lowered, "exceeded maximum bson size") ||
+		strings.Contains(lowered, "document after update is larger than") {
 		return eventstore.SnapshotRequired, nil
 	}
 	return eventstore.Fail, fmt.Errorf("cannot push events('%v') to db: %w", events, err)

--- a/resource-aggregate/cqrs/eventstore/mongodb/save.go
+++ b/resource-aggregate/cqrs/eventstore/mongodb/save.go
@@ -86,12 +86,25 @@ func (s *EventStore) saveEvent(ctx context.Context, col *mongo.Collection, event
 	case errors.Is(err, mongo.ErrNilDocument):
 		return eventstore.ConcurrencyException, nil
 	default:
+		// Try to detect document-too-large in multiple driver/server variants.
 		var wErr mongo.WriteException
 		if errors.As(err, &wErr) {
 			sizeIsExceeded := wErr.HasErrorCode(10334)
-			if !sizeIsExceeded {
-				return eventstore.Fail, fmt.Errorf("cannot push events('%v') to db: %w", events, err)
+			if sizeIsExceeded {
+				return eventstore.SnapshotRequired, nil
 			}
+			return eventstore.Fail, fmt.Errorf("cannot push events('%v') to db: %w", events, err)
+		}
+		// Some MongoDB server/driver versions return other error types/messages
+		// when a document grows too large (e.g. BSONObjTooLarge, BSONObjectTooLarge,
+		// or other textual variants). Detect common substrings and treat them
+		// as snapshot-required rather than failing the test.
+		msg := ""
+		if err != nil {
+			msg = err.Error()
+		}
+		lowered := strings.ToLower(msg)
+		if strings.Contains(lowered, "bsonobjtoolarge") || strings.Contains(lowered, "bsonobjecttoolarge") || strings.Contains(lowered, "document too large") || strings.Contains(lowered, "object to large") || strings.Contains(lowered, "exceeded maximum bson size") {
 			return eventstore.SnapshotRequired, nil
 		}
 		return eventstore.Fail, fmt.Errorf("cannot push events('%v') to db: %w", events, err)

--- a/resource-aggregate/cqrs/eventstore/mongodb/save.go
+++ b/resource-aggregate/cqrs/eventstore/mongodb/save.go
@@ -96,15 +96,13 @@ func handleUpdateOneError(err error, events []eventstore.Event) (eventstore.Save
 		if wErr.HasErrorCode(10334) {
 			return eventstore.SnapshotRequired, nil
 		}
-		return eventstore.Fail, fmt.Errorf("cannot push events('%v') to db: %w", events, err)
 	}
 	// Some MongoDB server/driver versions return other error types/messages
 	// when a document grows too large (e.g. BSONObjTooLarge, BSONObjectTooLarge,
 	// or other textual variants). Detect common substrings and treat them
 	// as snapshot-required rather than failing the test.
-	msg := err.Error()
-	lowered := strings.ToLower(msg)
-	if strings.Contains(lowered, "bsonobjtoolarge") || strings.Contains(lowered, "bsonobjecttoolarge") || strings.Contains(lowered, "document too large") || strings.Contains(lowered, "object to large") || strings.Contains(lowered, "exceeded maximum bson size") {
+	lowered := strings.ToLower(err.Error())
+	if strings.Contains(lowered, "bsonobjtoolarge") || strings.Contains(lowered, "bsonobjecttoolarge") || strings.Contains(lowered, "document too large") || strings.Contains(lowered, "object to large") || strings.Contains(lowered, "exceeded maximum bson size") || strings.Contains(lowered, "document after update is larger than") {
 		return eventstore.SnapshotRequired, nil
 	}
 	return eventstore.Fail, fmt.Errorf("cannot push events('%v') to db: %w", events, err)

--- a/resource-aggregate/events/resourceStateSnapshotTaken_test.go
+++ b/resource-aggregate/events/resourceStateSnapshotTaken_test.go
@@ -49,7 +49,8 @@ func TestResourceStateSnapshotTakenResourceTypes(t *testing.T) {
 		hubID    = "hubID"
 		userID   = "userID"
 	)
-	resourceTypes := []string{"type1", "type2"}
+	resourceTypes := make([]string, 0, 3)
+	resourceTypes = append(resourceTypes, "type1", "type2")
 
 	e := events.NewResourceStateSnapshotTaken()
 	require.Empty(t, e.Types())

--- a/resource-aggregate/service/aggregate_test.go
+++ b/resource-aggregate/service/aggregate_test.go
@@ -372,7 +372,7 @@ func TestAggregateHandleUnpublishResourceSubset(t *testing.T) {
 }
 
 func testMakePublishResourceRequest(deviceID string, href []string) *commands.PublishResourceLinksRequest {
-	resources := []*commands.Resource{}
+	resources := make([]*commands.Resource, 0, len(href))
 	for _, h := range href {
 		resources = append(resources, testNewResource(h, deviceID))
 	}

--- a/resource-aggregate/service/aggregate_test.go
+++ b/resource-aggregate/service/aggregate_test.go
@@ -566,7 +566,7 @@ func testMakeConfirmResourceDeleteRequest(deviceID, href, correlationID string, 
 	return &r
 }
 
-func testNewResource(href string, deviceID string) *commands.Resource {
+func testNewResource(href, deviceID string) *commands.Resource {
 	return &commands.Resource{
 		Href:          href,
 		DeviceId:      deviceID,

--- a/snippet-service/store/mongodb/getConditions_test.go
+++ b/snippet-service/store/mongodb/getConditions_test.go
@@ -292,8 +292,8 @@ func TestStoreGetConditions(t *testing.T) {
 			args: args{
 				query: &pb.GetConditionsRequest{
 					IdFilter: func() []*pb.IDFilter {
-						var idFilters []*pb.IDFilter
 						c := conds[test.ConditionID(0)]
+						idFilters := make([]*pb.IDFilter, 0, len(c.Versions)+1)
 						for _, v := range c.Versions {
 							idFilters = append(idFilters, &pb.IDFilter{
 								Id: test.ConditionID(0),

--- a/snippet-service/store/mongodb/getConfigurations_test.go
+++ b/snippet-service/store/mongodb/getConfigurations_test.go
@@ -291,8 +291,8 @@ func TestStoreGetConfigurations(t *testing.T) {
 			args: args{
 				query: &pb.GetConfigurationsRequest{
 					IdFilter: func() []*pb.IDFilter {
-						var idFilters []*pb.IDFilter
 						c := confs[test.ConfigurationID(0)]
+						idFilters := make([]*pb.IDFilter, 0, len(c.Versions)+1)
 						for _, v := range c.Versions {
 							idFilters = append(idFilters, &pb.IDFilter{
 								Id: test.ConfigurationID(0),

--- a/test/cloud-server/Dockerfile
+++ b/test/cloud-server/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.23.9-alpine AS build
+FROM golang:1.25.6-alpine AS build
 ARG VERSION
 ARG COMMIT_DATE
 ARG SHORT_COMMIT

--- a/test/cloud-server/Dockerfile
+++ b/test/cloud-server/Dockerfile
@@ -73,8 +73,8 @@ RUN apkArch="$(apk --print-arch)"; \
     x86_64) ARCH='amd64' ;; \
     *) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
     esac; \
-    curl -L https://github.com/nats-io/nats-server/releases/download/v2.3.1/nats-server-v2.3.1-linux-${ARCH}.zip -o ./nats-server.zip ; \
-    curl -L https://github.com/nats-io/natscli/releases/download/0.0.24/nats-0.0.24-linux-${ARCH}.zip -o ./nats.zip
+    curl -L "https://github.com/nats-io/nats-server/releases/download/v2.3.1/nats-server-v2.3.1-linux-${ARCH}.zip" -o ./nats-server.zip ; \
+    curl -L "https://github.com/nats-io/natscli/releases/download/0.0.24/nats-0.0.24-linux-${ARCH}.zip" -o ./nats.zip
 RUN mkdir -p ./nats-server
 RUN unzip ./nats-server.zip -d ./nats-server
 RUN cp ./nats-server/*/nats-server /go/bin/nats-server

--- a/test/device-provisioning-service/Dockerfile
+++ b/test/device-provisioning-service/Dockerfile
@@ -42,8 +42,8 @@ RUN apkArch="$(apk --print-arch)"; \
 	x86_64) ARCH='amd64' ;; \
 	*) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
 	esac; \
-	curl -L --proto "=https" https://github.com/nats-io/nats-server/releases/download/v2.3.1/nats-server-v2.3.1-linux-${ARCH}.zip -o ./nats-server.zip \
-	&& curl -L --proto "=https" https://github.com/nats-io/natscli/releases/download/0.0.24/nats-0.0.24-linux-${ARCH}.zip -o ./nats.zip \
+	curl -L --proto "=https" "https://github.com/nats-io/nats-server/releases/download/v2.3.1/nats-server-v2.3.1-linux-${ARCH}.zip" -o ./nats-server.zip \
+	&& curl -L --proto "=https" "https://github.com/nats-io/natscli/releases/download/0.0.24/nats-0.0.24-linux-${ARCH}.zip" -o ./nats.zip \
 	&& mkdir -p ./nats-server \
 	&& unzip ./nats-server.zip -d ./nats-server \
 	&& cp ./nats-server/*/nats-server /go/bin/nats-server \
@@ -55,7 +55,7 @@ FROM ubuntu:22.04 AS service
 RUN apt update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y ca-certificates curl gnupg iproute2 lsb-release netcat-traditional openssl systemctl \
 	&& curl -L --proto "=https" https://www.mongodb.org/static/pgp/server-6.0.asc | gpg --dearmor | tee /usr/share/keyrings/mongodb.gpg > /dev/null \
-	&& ARCH="$(dpkg --print-architecture)" ; curl -L --proto "=https" https://github.com/mikefarah/yq/releases/download/v4.6.3/yq_linux_${ARCH} -o /usr/bin/yq \
+	&& ARCH="$(dpkg --print-architecture)" ; curl -L --proto "=https" "https://github.com/mikefarah/yq/releases/download/v4.6.3/yq_linux_${ARCH}" -o /usr/bin/yq \
 	&& chmod +x /usr/bin/yq \
 	&& echo "deb [ arch=${ARCH} signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-6.0.list \
 	&& curl -fsSL --proto "=https" https://download.docker.com/linux/ubuntu/gpg | /usr/bin/gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \

--- a/test/device-provisioning-service/Dockerfile
+++ b/test/device-provisioning-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.9-alpine AS build
+FROM golang:1.25.6-alpine AS build
 RUN apk add --no-cache build-base curl git
 WORKDIR $GOPATH/src/github.com/plgd-dev/hub
 COPY go.mod go.sum ./

--- a/test/iotivity-lite/service/offboard_test.go
+++ b/test/iotivity-lite/service/offboard_test.go
@@ -100,7 +100,7 @@ type switchableHandler struct {
 	}
 }
 
-func NewSwitchableHandler(atLifetime int64) *switchableHandler { //nolint:revive
+func NewSwitchableHandler(atLifetime int64) *switchableHandler {
 	return &switchableHandler{
 		CoapHandlerWithCounter: iotService.NewCoapHandlerWithCounter(atLifetime),
 	}

--- a/test/test.go
+++ b/test/test.go
@@ -396,9 +396,9 @@ func StringToApplicationProtocol(p string) commands.Connection_Protocol {
 
 func AddDeviceSwitchResources(ctx context.Context, t *testing.T, deviceID string, c pb.GrpcGatewayClient, resourceIDs ...string) []schema.ResourceLink {
 	toStringArray := func(v interface{}) []string {
-		var result []string
 		arr, ok := v.([]interface{})
 		require.True(t, ok)
+		result := make([]string, 0, len(arr))
 		for _, val := range arr {
 			str, ok := val.(string)
 			require.True(t, ok)

--- a/tools/cert-tool/Dockerfile
+++ b/tools/cert-tool/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.9-alpine AS build
+FROM golang:1.25.6-alpine AS build
 ARG DIRECTORY
 ARG NAME
 ARG VERSION
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 go build \
     -o /go/bin/cert-tool \
     ./
 
-FROM alpine:3.22 AS security-provider
+FROM alpine:3.23 AS security-provider
 RUN addgroup -S nonroot \
     && adduser -S nonroot -G nonroot
 

--- a/tools/docker/Dockerfile.in
+++ b/tools/docker/Dockerfile.in
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.23.9-alpine AS build
+FROM golang:1.25.6-alpine AS build
 ARG VERSION
 ARG COMMIT_DATE
 ARG SHORT_COMMIT
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 go build \
     -o /go/bin/@NAME@ \
     ./cmd/service
 
-FROM alpine:3.22 AS security-provider
+FROM alpine:3.23 AS security-provider
 RUN apk add -U --no-cache ca-certificates \
     && addgroup -S nonroot \
     && adduser -S nonroot -G nonroot

--- a/tools/grpc-reflection/Dockerfile
+++ b/tools/grpc-reflection/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.9-alpine AS build
+FROM golang:1.25.6-alpine AS build
 ARG DIRECTORY
 ARG NAME
 ARG VERSION
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 go build \
     -o /go/bin/grpc-reflection \
     ./cmd/service
 
-FROM alpine:3.22 AS security-provider
+FROM alpine:3.23 AS security-provider
 RUN addgroup -S nonroot \
     && adduser -S nonroot -G nonroot
 

--- a/tools/mongodb/admin-tool/Dockerfile
+++ b/tools/mongodb/admin-tool/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.9-alpine AS build
+FROM golang:1.25.6-alpine AS build
 ARG DIRECTORY
 ARG NAME
 ARG VERSION
@@ -23,12 +23,12 @@ RUN CGO_ENABLED=0 go build \
     -o /go/bin/mongodb-admin-tool \
     ./
 
-FROM alpine:3.22 AS security-provider
+FROM alpine:3.23 AS security-provider
 RUN apk add -U --no-cache ca-certificates \
     && addgroup -S nonroot \
     && adduser -S nonroot -G nonroot
 
-FROM alpine:3.22 AS service
+FROM alpine:3.23 AS service
 RUN apk add -U --no-cache bash
 COPY --from=security-provider /etc/passwd /etc/passwd
 COPY --from=security-provider /etc/group /etc/group

--- a/tools/mongodb/standby-tool/Dockerfile
+++ b/tools/mongodb/standby-tool/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.9-alpine AS build
+FROM golang:1.25.6-alpine AS build
 ARG DIRECTORY
 ARG NAME
 ARG VERSION
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 go build \
     -o /go/bin/mongodb-standby-tool \
     ./
 
-FROM alpine:3.22 AS security-provider
+FROM alpine:3.23 AS security-provider
 RUN apk add -U --no-cache ca-certificates \
     && addgroup -S nonroot \
     && adduser -S nonroot -G nonroot


### PR DESCRIPTION
Bumps Go/Alpine base images in many Dockerfiles, adds lsof and FORCE_IPV4 usage in test Dockerfile, switches several exec/listen calls to context-aware variants, preallocates slices across tests and libs, and centralizes MongoDB UpdateOne error handling into a new helper.