### PR TITLE
chore: upgrade helm to 3.10.0 for publish chart

### DIFF
--- a/.github/workflows/releaseHelmCharts.yml
+++ b/.github/workflows/releaseHelmCharts.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           charts_url: https://charts.plgd.dev
-          helm_version: "3.7.1"
+          helm_version: "3.10.0"
           app_version: "${{ steps.get_version.outputs.VERSION }}"
           chart_version: "${{ steps.get_version.outputs.VERSION }}"


### PR DESCRIPTION
## Pull request overview

This PR upgrades the Helm version used in the GitHub Actions workflow for publishing Helm charts from 3.7.1 to 3.10.0. This is a minor version upgrade within Helm 3.x that maintains compatibility with the existing chart structure (apiVersion v2).

**Changes:**
- Updated `helm_version` parameter from "3.7.1" to "3.10.0" in the `releaseHelmCharts.yml` workflow